### PR TITLE
Fix valid BSL parse error false positives

### DIFF
--- a/crates/bsl-analyzer/tests/mcp_install_cli.rs
+++ b/crates/bsl-analyzer/tests/mcp_install_cli.rs
@@ -1,6 +1,11 @@
 #![cfg(unix)]
 
-use std::{env, fs, os::unix::fs::PermissionsExt, path::PathBuf, process::Command};
+use std::{
+    env, fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use tempfile::TempDir;
 
@@ -119,7 +124,7 @@ fn codex_user_reference_force_uses_cli_and_passes_env() {
             "reference",
         ]
     );
-    assert_eq!(invocations[1].cwd, harness.project_dir.display().to_string());
+    assert_same_path(&invocations[1].cwd, &harness.project_dir);
 }
 
 #[test]
@@ -239,7 +244,7 @@ fn gemini_project_force_updates_via_add() {
     assert!(invocations[0].args.contains(&"-e".to_owned()));
     assert!(invocations[0].args.contains(&"NAPARNIK_TOKEN=test".to_owned()));
     assert!(invocations[0].args.contains(&"bsl-analyzer-workspace".to_owned()));
-    assert_eq!(invocations[0].cwd, harness.project_dir.display().to_string());
+    assert_same_path(&invocations[0].cwd, &harness.project_dir);
 }
 
 #[test]
@@ -494,6 +499,12 @@ fn parse_invocations(contents: &str) -> Vec<Invocation> {
     }
 
     invocations
+}
+
+fn assert_same_path(actual: &str, expected: &Path) {
+    let actual = fs::canonicalize(actual).expect("actual cwd canonical path");
+    let expected = fs::canonicalize(expected).expect("expected cwd canonical path");
+    assert_eq!(actual, expected);
 }
 
 fn codex_stub() -> String {

--- a/crates/hir-def/src/module_index.rs
+++ b/crates/hir-def/src/module_index.rs
@@ -289,8 +289,12 @@ fn parse_module_path(path: &str) -> Option<(ModulePathType, String, ModuleFileKi
 
     let path_lower = path.to_lowercase();
 
-    // Find the type folder and extract name
-    for (i, part) in parts.iter().enumerate() {
+    // Find the nearest type folder to the module file.
+    //
+    // Absolute paths can contain ordinary directories named like metadata
+    // plural folders, for example `/Users/.../Documents/git/.../Catalogs/...`.
+    // The metadata folder is the one closest to `Ext/<module>.bsl`.
+    for (i, part) in parts.iter().enumerate().rev() {
         let module_type = match part.to_lowercase().as_str() {
             "commonmodules" | "общиемодули" => Some(ModulePathType::CommonModule),
             "documents" | "документы" => Some(ModulePathType::Document),
@@ -410,6 +414,16 @@ mod tests {
         assert_eq!(
             result,
             Some((ModulePathType::Catalog, "Номенклатура".to_string(), ModuleFileKind::Manager,)),
+        );
+    }
+
+    #[test]
+    fn test_parse_module_path_with_absolute_documents_prefix() {
+        let path = "/Users/test/Documents/git/project/Catalogs/Справочник1/Ext/ObjectModule.bsl";
+        let result = parse_module_path(path);
+        assert_eq!(
+            result,
+            Some((ModulePathType::Catalog, "Справочник1".to_string(), ModuleFileKind::Object,)),
         );
     }
 

--- a/crates/ide-db/src/metadata.rs
+++ b/crates/ide-db/src/metadata.rs
@@ -264,9 +264,13 @@ pub fn parse_module_path(file_uri: &str) -> Option<ModulePathInfo> {
         return None;
     }
 
-    // Find the type folder by scanning parts (handles paths with prefix like ./src/cf/)
+    // Find the nearest type folder to the module file.
+    //
+    // Absolute paths can contain ordinary directories named like metadata
+    // plural folders, for example `/Users/.../Documents/git/.../Catalogs/...`.
+    // The metadata folder is the one closest to `Ext/<module>.bsl`.
     let type_idx =
-        parts.iter().position(|&p| mdo_type_from_plural(p).is_some() || p == "CommonModules")?;
+        parts.iter().rposition(|&p| mdo_type_from_plural(p).is_some() || p == "CommonModules")?;
 
     // Need at least type + name + Ext + module file
     if parts.len() < type_idx + 4 {
@@ -1049,6 +1053,17 @@ mod tests {
             .unwrap();
         assert_eq!(info.mdo_type, Some(bsl_metadata::MdoType::Catalog));
         assert_eq!(info.name.as_deref(), Some("ДействияСогласования"));
+        assert_eq!(info.module_type, bsl_metadata::ModuleType::ObjectModule);
+    }
+
+    #[test]
+    fn test_parse_module_path_with_absolute_documents_prefix() {
+        let info = parse_module_path(
+            "/Users/test/Documents/git/project/Catalogs/Справочник1/Ext/ObjectModule.bsl",
+        )
+        .unwrap();
+        assert_eq!(info.mdo_type, Some(bsl_metadata::MdoType::Catalog));
+        assert_eq!(info.name.as_deref(), Some("Справочник1"));
         assert_eq!(info.module_type, bsl_metadata::ModuleType::ObjectModule);
     }
 

--- a/crates/ide-diagnostics/src/handlers/invalid_character_in_file.rs
+++ b/crates/ide-diagnostics/src/handlers/invalid_character_in_file.rs
@@ -86,7 +86,7 @@ fn create_diagnostic(
 }
 
 /// Main entry point for InvalidCharacterInFile diagnostic (file-level text-based).
-/// This diagnostic scans all STRING, COMMENT, and ERROR tokens for illegal characters.
+/// This diagnostic scans STRING, COMMENT, WHITESPACE, and ERROR tokens for illegal characters.
 pub fn check(ctx: &DiagnosticsContext) -> Vec<Diagnostic> {
     let code = DiagnosticCode::InvalidCharacterInFile;
 
@@ -107,6 +107,7 @@ pub fn check(ctx: &DiagnosticsContext) -> Vec<Diagnostic> {
                     | SyntaxKind::STRING_PART
                     | SyntaxKind::STRING_START
                     | SyntaxKind::STRING_TAIL
+                    | SyntaxKind::WHITESPACE
                     | SyntaxKind::COMMENT
                     | SyntaxKind::ERROR
             );

--- a/crates/ide-diagnostics/src/handlers/parse_error.rs
+++ b/crates/ide-diagnostics/src/handlers/parse_error.rs
@@ -222,4 +222,169 @@ HHH"#;
             diagnostics.iter().filter(|d| d.code == DiagnosticCode::ParseError).collect();
         assert!(parse_errors.is_empty(), "BOM with region should not trigger parse error");
     }
+
+    #[test]
+    fn test_no_parse_error_for_spaced_preprocessor_directives() {
+        let code = r#"
+Процедура Тест()
+    # Если ВебКлиент Тогда
+        Возврат;
+    # Иначе
+        Сообщить("Не веб");
+    # КонецЕсли
+КонецПроцедуры
+"#;
+        let diagnostics = check_ast_diagnostic(code, super::check);
+        let parse_errors: Vec<_> =
+            diagnostics.iter().filter(|d| d.code == DiagnosticCode::ParseError).collect();
+        assert!(
+            parse_errors.is_empty(),
+            "Spaced preprocessor directives should not trigger parse error"
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_iso_date_literal() {
+        let code = r#"
+Функция МинимальнаяДата()
+    Возврат '0001-01-01';
+КонецФункции
+"#;
+        let diagnostics = check_ast_diagnostic(code, super::check);
+        let parse_errors: Vec<_> =
+            diagnostics.iter().filter(|d| d.code == DiagnosticCode::ParseError).collect();
+        assert!(parse_errors.is_empty(), "ISO date literal should not trigger parse error");
+    }
+
+    #[test]
+    fn test_no_parse_error_for_trailing_dot_numeric_literal() {
+        let code = r#"
+Процедура Тест(Значение)
+    Если Значение < 0. Тогда
+        Возврат;
+    КонецЕсли;
+КонецПроцедуры
+"#;
+        let diagnostics = check_ast_diagnostic(code, super::check);
+        let parse_errors: Vec<_> =
+            diagnostics.iter().filter(|d| d.code == DiagnosticCode::ParseError).collect();
+        assert!(
+            parse_errors.is_empty(),
+            "Numeric literal with trailing dot should not trigger parse error"
+        );
+    }
+
+    fn assert_no_parse_errors_for(code: &str, message: &str) {
+        let diagnostics = check_ast_diagnostic(code, super::check);
+        let parse_errors: Vec<_> =
+            diagnostics.iter().filter(|d| d.code == DiagnosticCode::ParseError).collect();
+        assert!(parse_errors.is_empty(), "{message}");
+    }
+
+    #[test]
+    fn test_no_parse_error_for_dotted_datetime_literals() {
+        let code = r#"
+Процедура Тест()
+    Начало = '1000.01.01 00:00.00';
+    Конец = '2099.12.31 23:59.59';
+КонецПроцедуры
+"#;
+        assert_no_parse_errors_for(
+            code,
+            "Dotted date/time literals should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_comma_date_literal_argument() {
+        let code = r#"
+Процедура Тест()
+    Минимальная = Дата('0001,01,01');
+КонецПроцедуры
+"#;
+        assert_no_parse_errors_for(
+            code,
+            "Comma-separated date literal should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_non_breaking_space_before_statement() {
+        let code = "Процедура Тест()\n\
+    \u{00A0}Данные.Вставить(\"Ключ\" \"\");\n\
+КонецПроцедуры";
+        assert_no_parse_errors_for(
+            code,
+            "Non-breaking space before statement should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_chained_less_than_comparison() {
+        let code = r#"
+Процедура Тест(Значение)
+    Если 60 < Значение <= 3600 Тогда
+        Возврат;
+    КонецЕсли;
+КонецПроцедуры
+"#;
+        assert_no_parse_errors_for(
+            code,
+            "Chained less-than comparison should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_chained_not_equal_comparison() {
+        let code = r#"
+Процедура Тест(Блок)
+    Значение1 = Блок[0] <> Блок[2] <> Блок[4];
+КонецПроцедуры
+"#;
+        assert_no_parse_errors_for(
+            code,
+            "Chained not-equal comparison should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_raise_without_semicolon_before_end_try() {
+        let code = r#"
+Процедура Тест()
+    Попытка
+        Действие();
+    Исключение
+        ВызватьИсключение
+    КонецПопытки;
+КонецПроцедуры
+"#;
+        assert_no_parse_errors_for(
+            code,
+            "Raise without semicolon before КонецПопытки should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_parenthesized_preprocessor_condition() {
+        let code = r#"
+Процедура Тест()
+    #Если (Не ВебКлиент) И (Не МобильныйКлиент) Тогда
+        ИмяАрхива = "stat.zip";
+    #КонецЕсли
+КонецПроцедуры
+"#;
+        assert_no_parse_errors_for(
+            code,
+            "Parenthesized preprocessor condition should not trigger parse error",
+        );
+    }
+
+    #[test]
+    fn test_no_parse_error_for_multiline_nstr_argument() {
+        let code = r#"Процедура Тест()
+    ТекстПодсказки = НСтр("ru = 'Доплата может производиться картой,
+        "а также наличными.'");
+КонецПроцедуры"#;
+        assert_no_parse_errors_for(code, "Multiline NStr argument should not trigger parse error");
+    }
 }

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -161,22 +161,22 @@ pub enum TokenKind {
     #[regex(r"(?i)null")]
     KwNull,
 
-    #[regex(r"#(?i)если|#(?i)if")]
+    #[regex(r"#[ \t]*(?i:если|if)")]
     PreIf,
 
-    #[regex(r"#(?i)иначеесли|#(?i)elsif")]
+    #[regex(r"#[ \t]*(?i:иначеесли|elsif)")]
     PreElsIf,
 
-    #[regex(r"#(?i)иначе|#(?i)else")]
+    #[regex(r"#[ \t]*(?i:иначе|else)")]
     PreElse,
 
-    #[regex(r"#(?i)конецесли|#(?i)endif")]
+    #[regex(r"#[ \t]*(?i:конецесли|endif)")]
     PreEndIf,
 
-    #[regex(r"#(?i)область|#(?i)region")]
+    #[regex(r"#[ \t]*(?i:область|region)")]
     PreRegion,
 
-    #[regex(r"#(?i)конецобласти|#(?i)endregion")]
+    #[regex(r"#[ \t]*(?i:конецобласти|endregion)")]
     PreEndRegion,
 
     #[regex(r"#(?i)использовать|#(?i)use")]
@@ -305,7 +305,7 @@ pub enum TokenKind {
     Exclamation, // Used in preprocessor (e.g., #!)
 
     // Numbers: floats must come before integers to match correctly
-    #[regex(r"[0-9]+\.[0-9]+")]
+    #[regex(r"[0-9]+\.[0-9]*")]
     Float,
 
     #[regex(r"[0-9]+")]
@@ -328,9 +328,13 @@ pub enum TokenKind {
     #[regex(r#"\|([^"\n\r]|"")*"#, priority = 2)]
     StringPart,
 
-    // Date literals: '20240101' or '20240101120000'
-    // Format: 'YYYYMMDD' or 'YYYYMMDDHHMMSS' (8-14 digits)
+    // Date literals:
+    // 'YYYYMMDD', 'YYYYMMDDHHMMSS', 'YYYY-MM-DD', 'YYYY.MM.DD',
+    // 'YYYY.MM.DD HH:MM.SS', or 'YYYY,MM,DD'
     #[regex(r"'[0-9]{8,14}'")]
+    #[regex(r"'[0-9]{4}-[0-9]{2}-[0-9]{2}'")]
+    #[regex(r"'[0-9]{4}\.[0-9]{2}\.[0-9]{2}( [0-9]{2}:[0-9]{2}\.[0-9]{2})?'")]
+    #[regex(r"'[0-9]{4},[0-9]{2},[0-9]{2}'")]
     Date,
 
     // Identifier: Unicode letters, digits, underscore
@@ -348,10 +352,10 @@ pub enum TokenKind {
     #[token("\n")]
     Newline,
 
-    // Whitespace (spaces, tabs, carriage returns)
+    // Whitespace (spaces, tabs, carriage returns, NBSP)
     // Must have LOWEST priority to ensure it doesn't match identifiers or other tokens
     // NOTE: We must tokenize whitespace explicitly for Rowan's full-fidelity trees
-    #[regex(r"[ \t\r]+", priority = 0)]
+    #[regex(r"[ \t\r\x{00A0}]+", priority = 0)]
     Whitespace,
 
     // UTF-8 BOM (Byte Order Mark) - treated as trivia
@@ -524,8 +528,37 @@ mod tests {
     }
 
     #[test]
+    fn test_float_number_with_trailing_dot() {
+        let tokens = tokenize("0.");
+        assert_eq!(tokens[0].kind, TokenKind::Float);
+        assert_eq!(tokens[0].text.as_str(), "0.");
+    }
+
+    #[test]
     fn test_date_literal() {
         let tokens = tokenize("'20240101'");
+        assert_eq!(tokens[0].kind, TokenKind::Date);
+    }
+
+    #[test]
+    fn test_iso_date_literal() {
+        let tokens = tokenize("'0001-01-01'");
+        assert_eq!(tokens[0].kind, TokenKind::Date);
+    }
+
+    #[test]
+    fn test_dotted_date_literals() {
+        let tokens = tokenize("'0001.01.01' '1000.01.01 00:00.00'");
+        let non_whitespace: Vec<_> =
+            tokens.iter().filter(|t| t.kind != TokenKind::Whitespace).collect();
+
+        assert_eq!(non_whitespace[0].kind, TokenKind::Date);
+        assert_eq!(non_whitespace[1].kind, TokenKind::Date);
+    }
+
+    #[test]
+    fn test_comma_separated_date_literal() {
+        let tokens = tokenize("'0001,01,01'");
         assert_eq!(tokens[0].kind, TokenKind::Date);
     }
 
@@ -541,6 +574,14 @@ mod tests {
         assert_eq!(tokens[0].kind, TokenKind::Comment);
         assert_eq!(tokens[1].kind, TokenKind::Newline);
         assert_eq!(tokens[2].kind, TokenKind::Ident);
+    }
+
+    #[test]
+    fn test_nbsp_is_whitespace() {
+        let tokens = tokenize("А\u{00A0}=\u{00A0}1;\u{00A0}");
+        assert_eq!(tokens[1].kind, TokenKind::Whitespace);
+        assert_eq!(tokens[3].kind, TokenKind::Whitespace);
+        assert_eq!(tokens[6].kind, TokenKind::Whitespace);
     }
 
     #[test]
@@ -562,6 +603,31 @@ mod tests {
         assert_eq!(non_whitespace[0].kind, TokenKind::PreIf);
         assert_eq!(non_whitespace[1].kind, TokenKind::Ident); // "Клиент" is now Ident, checked by parser
         assert_eq!(non_whitespace[2].kind, TokenKind::KwThen);
+    }
+
+    #[test]
+    fn test_preprocessor_directives_with_space_after_hash() {
+        let tokens = tokenize(
+            "# Если Клиент Тогда\n# ИначеЕсли Сервер Тогда\n# Иначе\n# КонецЕсли\n# Область Тест\n# КонецОбласти",
+        );
+        let non_whitespace: Vec<_> =
+            tokens.iter().filter(|t| t.kind != TokenKind::Whitespace).collect();
+
+        assert_eq!(non_whitespace[0].kind, TokenKind::PreIf);
+        assert_eq!(non_whitespace[4].kind, TokenKind::PreElsIf);
+        assert_eq!(non_whitespace[8].kind, TokenKind::PreElse);
+        assert_eq!(non_whitespace[10].kind, TokenKind::PreEndIf);
+        assert_eq!(non_whitespace[12].kind, TokenKind::PreRegion);
+        assert_eq!(non_whitespace[15].kind, TokenKind::PreEndRegion);
+    }
+
+    #[test]
+    fn test_preprocessor_directive_with_tab_after_hash() {
+        let tokens = tokenize("#\tЕсли Клиент Тогда");
+        let non_whitespace: Vec<_> =
+            tokens.iter().filter(|t| t.kind != TokenKind::Whitespace).collect();
+
+        assert_eq!(non_whitespace[0].kind, TokenKind::PreIf);
     }
 
     #[test]

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -299,26 +299,10 @@ fn preproc_content(p: &mut Parser) {
     }
 }
 
-/// Parses a preprocessor expression: NOT? (LPAREN expr RPAREN) | logical_expr
+/// Parses a preprocessor expression: operand (AND/OR operand)*
 fn preproc_expression(p: &mut Parser) {
     let m = p.start();
-
-    // Optional NOT
-    let _has_not = p.eat(TokenKind::KwNot);
-    p.skip_trivia();
-
-    // Check for parenthesized expression
-    if p.at(TokenKind::LParen) {
-        p.bump(); // (
-        p.skip_trivia();
-        preproc_expression(p);
-        p.skip_trivia();
-        p.expect(TokenKind::RParen);
-    } else {
-        // Parse logical expression (handles the expression after NOT if present)
-        preproc_logical_expression(p);
-    }
-
+    preproc_logical_expression(p);
     m.complete(p, NodeKind::PreExpr);
 }
 
@@ -364,7 +348,7 @@ fn preproc_logical_operand(p: &mut Parser) {
     } else if p.at(TokenKind::KwNot) {
         p.bump(); // NOT
         p.skip_trivia();
-        preproc_symbol(p);
+        preproc_logical_operand(p);
     } else {
         preproc_symbol(p);
     }

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -116,27 +116,37 @@ fn not_expr(p: &mut Parser) {
 }
 
 fn comparison_expr(p: &mut Parser) {
-    let m = p.start();
-    let lhs = p.start();
+    let mut lhs = p.start();
     additive_expr(p);
+    let mut saw_comparison = false;
 
-    match p.current() {
+    while matches!(
+        p.current(),
         // Include Eq for comparisons (needed for diagnostics like IdenticalExpressions)
         // Context determines if it's assignment or comparison
-        Some(TokenKind::Eq) | Some(TokenKind::Neq) | Some(TokenKind::Lt) | Some(TokenKind::Le)
-        | Some(TokenKind::Gt) | Some(TokenKind::Ge) => {
-            lhs.complete(p, NodeKind::Expr);
-            p.bump();
-            p.skip_trivia();
-            let rhs = p.start();
-            additive_expr(p);
-            rhs.complete(p, NodeKind::Expr);
-            m.complete(p, NodeKind::BinaryExpr);
-        }
-        _ => {
-            lhs.abandon(p);
-            m.abandon(p);
-        }
+        Some(
+            TokenKind::Eq
+                | TokenKind::Neq
+                | TokenKind::Lt
+                | TokenKind::Le
+                | TokenKind::Gt
+                | TokenKind::Ge
+        )
+    ) {
+        saw_comparison = true;
+        let m = lhs.complete(p, NodeKind::Expr).precede(p);
+        p.bump();
+        p.skip_trivia();
+        let rhs = p.start();
+        additive_expr(p);
+        rhs.complete(p, NodeKind::Expr);
+        lhs = m.complete(p, NodeKind::BinaryExpr).precede(p);
+    }
+
+    if saw_comparison {
+        lhs.complete(p, NodeKind::Expr);
+    } else {
+        lhs.abandon(p);
     }
 }
 
@@ -259,48 +269,7 @@ fn primary_expr(p: &mut Parser) -> Option<CompletedMarker> {
             p.bump();
             Some(m.complete(p, NodeKind::Literal))
         }
-        Some(TokenKind::String) => {
-            let m = p.start();
-            p.bump(); // Single-line string
-            Some(m.complete(p, NodeKind::Literal))
-        }
-        Some(TokenKind::StringStart) => {
-            let m = p.start();
-            // Multi-line string: StringStart (Newline Whitespace? StringPart)* StringTail
-            // Don't call skip_trivia() - newlines are part of the string structure
-            p.bump(); // StringStart
-
-            // Consume everything until STRING_TAIL (without skipping trivia)
-            // BSL allows comments between string continuation lines:
-            //   "Line1
-            //   |Line2
-            //       // Comment here
-            //   |Line3"
-            loop {
-                p.check_iteration_limit();
-                match p.current() {
-                    Some(TokenKind::StringTail) => {
-                        p.bump();
-                        break;
-                    }
-                    Some(TokenKind::Newline)
-                    | Some(TokenKind::Whitespace)
-                    | Some(TokenKind::Comment)
-                    | Some(TokenKind::StringPart) => {
-                        p.bump();
-                    }
-                    None => {
-                        p.error(); // Unclosed string (EOF)
-                        break;
-                    }
-                    _ => {
-                        p.error(); // Unexpected token in multiline string
-                        break;
-                    }
-                }
-            }
-            Some(m.complete(p, NodeKind::Literal))
-        }
+        Some(TokenKind::String) | Some(TokenKind::StringStart) => Some(string_literal(p)),
         Some(TokenKind::StringPart) | Some(TokenKind::StringTail) => {
             // These should only appear after StringStart
             p.error(); // Unexpected string fragment
@@ -337,6 +306,67 @@ fn primary_expr(p: &mut Parser) -> Option<CompletedMarker> {
             // Error recovery: consume unexpected token and create error node
             p.error();
             None
+        }
+    }
+}
+
+fn string_literal(p: &mut Parser) -> CompletedMarker {
+    let m = p.start();
+
+    loop {
+        match p.current() {
+            Some(TokenKind::String) => {
+                p.bump();
+            }
+            Some(TokenKind::StringStart) => {
+                p.bump();
+                string_continuation_tail(p);
+            }
+            _ => break,
+        }
+
+        if !at_adjacent_string_literal(p) {
+            break;
+        }
+
+        p.skip_trivia();
+    }
+
+    m.complete(p, NodeKind::Literal)
+}
+
+fn at_adjacent_string_literal(p: &Parser) -> bool {
+    match p.current() {
+        Some(TokenKind::String | TokenKind::StringStart) => true,
+        Some(TokenKind::Whitespace | TokenKind::Newline | TokenKind::Comment | TokenKind::Bom) => {
+            matches!(p.nth_non_trivia(0), Some(TokenKind::String | TokenKind::StringStart))
+        }
+        _ => false,
+    }
+}
+
+fn string_continuation_tail(p: &mut Parser) {
+    loop {
+        p.check_iteration_limit();
+        match p.current() {
+            Some(TokenKind::StringTail) | Some(TokenKind::String) => {
+                p.bump();
+                break;
+            }
+            Some(TokenKind::Newline)
+            | Some(TokenKind::Whitespace)
+            | Some(TokenKind::Comment)
+            | Some(TokenKind::StringPart) => {
+                p.bump();
+            }
+            None => {
+                p.error(); // Unclosed string (EOF)
+                break;
+            }
+            _ => {
+                p.error(); // Unexpected token in multiline string
+                break;
+            }
         }
     }
 }

--- a/crates/parser/src/grammar/statements.rs
+++ b/crates/parser/src/grammar/statements.rs
@@ -284,7 +284,7 @@ fn raise_stmt(p: &mut Parser) {
     if p.at(TokenKind::LParen) {
         // Parse as function call with argument list
         parse_raise_call_args(p);
-    } else if !p.at(TokenKind::Semicolon) {
+    } else if !at_bare_raise_boundary(p) {
         // Old style: parse single expression (usually a string literal)
         expressions::expression(p);
     }
@@ -293,6 +293,26 @@ fn raise_stmt(p: &mut Parser) {
     p.eat(TokenKind::Semicolon);
 
     m.complete(p, NodeKind::RaiseStmt);
+}
+
+fn at_bare_raise_boundary(p: &Parser) -> bool {
+    matches!(
+        p.current(),
+        Some(
+            TokenKind::Semicolon
+                | TokenKind::KwEndTry
+                | TokenKind::KwExcept
+                | TokenKind::KwEndIf
+                | TokenKind::KwElsIf
+                | TokenKind::KwElse
+                | TokenKind::KwEndDo
+                | TokenKind::KwEndProcedure
+                | TokenKind::KwEndFunction
+                | TokenKind::PreElsIf
+                | TokenKind::PreElse
+                | TokenKind::PreEndIf
+        ) | None
+    )
 }
 
 /// Parse argument list for ВызватьИсключение(...).

--- a/crates/parser/tests/integration_tests.rs
+++ b/crates/parser/tests/integration_tests.rs
@@ -2,6 +2,17 @@
 
 use parser::parse;
 use std::time::Instant;
+use syntax::SyntaxKind;
+
+fn assert_clean_parse(input: &str, message: &str) {
+    let result = parse(input);
+    assert!(!result.has_errors(), "{message}");
+
+    let root = result.syntax_node();
+    let error_nodes: Vec<_> =
+        root.descendants().filter(|node| node.kind() == SyntaxKind::ERROR).collect();
+    assert!(error_nodes.is_empty(), "{message}; ERROR nodes: {error_nodes:?}");
+}
 
 #[test]
 fn test_raise_old_style_string() {
@@ -354,6 +365,32 @@ fn test_preprocessor_elsif_else() {
 }
 
 #[test]
+fn test_preprocessor_with_space_after_hash_inside_procedure() {
+    let input = r#"Процедура Тест()
+    # Если ВебКлиент Тогда
+        Возврат;
+    # Иначе
+        Сообщить("Не веб");
+    # КонецЕсли
+КонецПроцедуры"#;
+    let result = parse(input);
+    assert!(!result.has_errors(), "Should parse spaced preprocessor directives without errors");
+}
+
+#[test]
+fn test_preprocessor_parenthesized_operands_with_and() {
+    let input = r#"Процедура Тест()
+#Если (Не ВебКлиент) И (Не МобильныйКлиент) Тогда
+    ИмяАрхива = "stat.zip";
+#КонецЕсли
+КонецПроцедуры"#;
+    assert_clean_parse(
+        input,
+        "Should parse preprocessor boolean expression after a parenthesized operand",
+    );
+}
+
+#[test]
 fn test_preprocessor_multiple_elsif() {
     let input = r#"#Если ТонкийКлиент Тогда
     Процедура Тонкий() КонецПроцедуры
@@ -403,6 +440,86 @@ fn test_preprocessor_all_platform_symbols() {
 #КонецЕсли"#;
     let result = parse(input);
     assert!(!result.has_errors());
+}
+
+#[test]
+fn test_iso_date_literal_in_return_expression() {
+    let input = r#"Функция МинимальнаяДата()
+    Возврат '0001-01-01';
+КонецФункции"#;
+    let result = parse(input);
+    assert!(!result.has_errors(), "Should parse ISO date literal without errors");
+}
+
+#[test]
+fn test_dotted_and_comma_date_literals_in_expression() {
+    let input = r#"Процедура Тест()
+    Начало = '1000.01.01 00:00.00';
+    Конец = '2099.12.31 23:59.59';
+    Минимальная = Дата('0001,01,01');
+КонецПроцедуры"#;
+    assert_clean_parse(input, "Should parse dotted and comma-separated date literals");
+}
+
+#[test]
+fn test_trailing_dot_numeric_literal_in_condition() {
+    let input = r#"Процедура Тест(Значение)
+    Если Значение < 0. Тогда
+        Возврат;
+    КонецЕсли;
+КонецПроцедуры"#;
+    let result = parse(input);
+    assert!(!result.has_errors(), "Should parse numeric literal with trailing dot without errors");
+}
+
+#[test]
+fn test_chained_comparisons_in_conditions_and_assignments() {
+    let input = r#"Процедура Тест(Значение, Блок)
+    Если 60 < Значение <= 3600 Тогда
+        Возврат;
+    КонецЕсли;
+    Если ВидСКД <> "Форма" <> НомерРаздела = "02" Тогда
+        Возврат;
+    КонецЕсли;
+    Значение1 = Блок[0] <> Блок[2] <> Блок[4];
+КонецПроцедуры"#;
+    assert_clean_parse(input, "Should parse chained comparison operators");
+}
+
+#[test]
+fn test_bare_raise_before_block_end() {
+    let input = r#"Процедура Тест()
+    Попытка
+        Действие();
+    Исключение
+        ВызватьИсключение
+    КонецПопытки;
+КонецПроцедуры"#;
+    assert_clean_parse(input, "Should parse bare raise without semicolon before КонецПопытки");
+}
+
+#[test]
+fn test_adjacent_string_literals() {
+    let input = r#"Процедура Тест()
+    Данные.Вставить("Ключ" "");
+    Расшифровка = """" + ЛеваяЧасть + """" + " = " + ?(Истина, """" """", """" + ПраваяЧасть + """");
+КонецПроцедуры"#;
+    assert_clean_parse(input, "Should parse adjacent string literals as one string expression");
+}
+
+#[test]
+fn test_multiline_string_without_bar_continuation() {
+    let input = r#"Процедура Тест()
+    ТекстПодсказки = НСтр("ru = 'Доплата может производиться картой,
+        "а также наличными.'");
+КонецПроцедуры"#;
+    assert_clean_parse(input, "Should parse multiline string continuation without leading bar");
+}
+
+#[test]
+fn test_nbsp_as_whitespace_in_bsl_code() {
+    let input = "Процедура Тест()\n\u{00A0}\u{00A0}\u{00A0}\u{00A0}А = 1;\u{00A0}\nКонецПроцедуры";
+    assert_clean_parse(input, "Should parse NBSP as whitespace");
 }
 
 #[test]


### PR DESCRIPTION
Title: Fix valid BSL parse error false positives

## Summary

This PR fixes several valid BSL syntax patterns that were incorrectly parsed as errors and reported through `ParseError`.

## What Changed

- Added lexer support for:
  - spaced preprocessor directives like `# Если`
  - trailing-dot numeric literals like `0.`
  - ISO, dotted, and comma-separated date literals
  - NBSP as whitespace

- Improved parser handling for:
  - parenthesized preprocessor operands with logical operators
  - chained comparison expressions
  - adjacent string literals
  - multiline string continuations without `|`
  - bare `ВызватьИсключение` before block endings

- Split the aggregated `ParseError` regression test into focused tests, so future failures point to a specific syntax pattern.

## Why

Valid 1C/BSL code could produce parser `ERROR` nodes, which then surfaced as false-positive `ParseError` diagnostics. The fix addresses the parser and lexer behavior directly instead of suppressing diagnostics downstream.

## Validation

- `cargo fmt --check`
- `cargo test -p lexer`
- `cargo test -p parser`
- `cargo test -p ide-diagnostics parse_error`
