### PR TITLE
fix(onec-client): принимать UTF-8 BOM в JSON-ответах 1С

### DIFF
--- a/crates/onec-client/src/lib.rs
+++ b/crates/onec-client/src/lib.rs
@@ -8,6 +8,9 @@ pub enum Error {
     #[error("HTTP request failed: {0}")]
     Request(#[from] reqwest::Error),
 
+    #[error("invalid JSON response from 1C: {0}")]
+    Decode(#[from] serde_json::Error),
+
     #[error("1C returned status {status}: {body}")]
     Status { status: u16, body: String },
 
@@ -107,8 +110,14 @@ impl Client {
             return Err(Error::Status { status: status.as_u16(), body });
         }
 
-        Ok(resp.json().await?)
+        let body = resp.bytes().await?;
+        decode_json(&body)
     }
+}
+
+fn decode_json<R: for<'de> Deserialize<'de>>(body: &[u8]) -> Result<R, Error> {
+    let body = body.strip_prefix(b"\xEF\xBB\xBF").unwrap_or(body);
+    Ok(serde_json::from_slice(body)?)
 }
 
 #[derive(Debug, Serialize)]
@@ -260,5 +269,15 @@ mod tests {
         let value = serde_json::to_value(request).unwrap();
         assert_eq!(value["meta_type"], "Catalogs");
         assert_eq!(value["name"], "Организации");
+    }
+
+    #[test]
+    fn response_decoder_accepts_utf8_bom_emitted_by_1c() {
+        let result: QueryResult = decode_json(
+            b"\xEF\xBB\xBF{\"columns\":[\"Value\"],\"rows\":[[1]],\"total\":1,\"truncated\":false}",
+        )
+        .unwrap();
+        assert_eq!(result.total, 1);
+        assert_eq!(result.rows[0][0], 1);
     }
 }


### PR DESCRIPTION
## Проблема

HTTP-сервис 1С может вернуть корректный UTF-8 JSON с BOM (`EF BB BF`). `reqwest::Response::json()` передавал такое тело декодеру без удаления BOM, поэтому живые MCP-запросы завершались ошибкой декодирования при HTTP 200.

## Исправление

- читать тело ответа как байты;
- удалять необязательный UTF-8 BOM;
- разбирать JSON через `serde_json::from_slice`;
- возвращать отдельную ошибку декодирования;
- проверять поведение регрессионным тестом.

## Проверки

- `cargo fmt --all -- --check`
- `cargo test -p onec-client` — 3 passed
- живой запрос к HTTP-сервису 1С после исправления успешно разбирает ответ с BOM.