### PR TITLE
fix(mcp): keep broker alive during background indexing

### DIFF
--- a/crates/mcp-server/src/broker/daemon.rs
+++ b/crates/mcp-server/src/broker/daemon.rs
@@ -181,6 +181,8 @@ async fn serve(
                         "backend superseded by a newer daemon generation and idle; shutting down"
                     );
                     break;
+                } else if server.background_work_active() {
+                    idle_since = None;
                 } else {
                     let grace = if warmed.load(Ordering::SeqCst) { idle_ttl } else { orphan_grace };
                     let since = *idle_since.get_or_insert_with(Instant::now);

--- a/crates/mcp-server/src/change_hub.rs
+++ b/crates/mcp-server/src/change_hub.rs
@@ -4454,6 +4454,7 @@ mod tests {
     /// nothing on Windows (`\\?\C:\...` against `C:\...`) while staying green anywhere
     /// the two happen to coincide; a symlinked root is the same defect, reproducible here.
     #[test]
+    #[cfg(unix)]
     fn the_excluded_root_is_recognised_under_either_spelling() {
         let real = tempdir().unwrap();
         let links = tempdir().unwrap();

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -970,6 +970,10 @@ impl McpServer {
         self.state.superseded()
     }
 
+    pub(crate) fn background_work_active(&self) -> bool {
+        self.state.background_work_active()
+    }
+
     /// Browse the configuration's metadata: objects, their structure, and managed forms.
     /// Use to answer "what objects exist / what does object X contain / what is on form Y" —
     /// attributes, tabular sections, forms, types — straight from the metadata substrate. Not

--- a/crates/mcp-server/src/state/bootstrap.rs
+++ b/crates/mcp-server/src/state/bootstrap.rs
@@ -161,6 +161,12 @@ impl ReferenceSearchState {
         self.lifecycle.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).clone()
     }
 
+    pub(super) fn loading(&self) -> bool {
+        self.lifecycle
+            .try_lock()
+            .map_or(true, |lifecycle| matches!(*lifecycle, ReferenceSearchLifecycle::Loading))
+    }
+
     pub(super) fn shutdown(&self) {
         self.stopped.store(true, Ordering::Release);
         self.baseline.shutdown();
@@ -303,6 +309,7 @@ impl SharedState {
         );
 
         let search_engine: SharedSearchEngine = Arc::new(Mutex::new(None));
+        let workspace_search_initializing = Arc::new(AtomicBool::new(true));
         let index_progress = IndexProgress::new();
         let semantic_runtime = Arc::new(Mutex::new(SemanticRuntimeStatus::Disabled));
         let overlay_warmup = Arc::new(Mutex::new(OverlayWarmupState::Pending));
@@ -424,6 +431,7 @@ impl SharedState {
         // closure is dropped unrun.
         Self::spawn_workspace_search_init(
             Arc::clone(&search_engine),
+            Arc::clone(&workspace_search_initializing),
             Arc::clone(&index_progress),
             Arc::clone(&semantic_runtime),
             source_dir.clone(),
@@ -448,6 +456,7 @@ impl SharedState {
             onec_connections: Default::default(),
             debug_session: Arc::new(Mutex::new(None)),
             search_engine,
+            workspace_search_initializing,
             index_progress,
             semantic_runtime,
             overlay_warmup,
@@ -470,6 +479,7 @@ impl SharedState {
     #[allow(clippy::too_many_arguments)]
     fn spawn_workspace_search_init(
         search_engine: SharedSearchEngine,
+        initializing: Arc<AtomicBool>,
         index_progress: Arc<IndexProgress>,
         semantic_runtime: Arc<Mutex<SemanticRuntimeStatus>>,
         workspace_root: PathBuf,
@@ -485,9 +495,17 @@ impl SharedState {
         root_drift_epoch: Arc<AtomicU64>,
         embedding_publish_retry_budget: std::time::Duration,
     ) {
-        std::thread::Builder::new()
+        let initializing_for_thread = Arc::clone(&initializing);
+        let spawned = std::thread::Builder::new()
             .name("bsl-search-init".to_owned())
             .spawn(move || {
+                struct InitializingGuard(Arc<AtomicBool>);
+                impl Drop for InitializingGuard {
+                    fn drop(&mut self) {
+                        self.0.store(false, Ordering::Relaxed);
+                    }
+                }
+                let _initializing = InitializingGuard(initializing_for_thread);
                 tracing::info!("search engine initialization started in background");
 
                 // The graph is a boot subsystem like the resident, not a lazy one. In
@@ -741,8 +759,10 @@ impl SharedState {
                         retry.kick_fresh();
                     }
                 }
-            })
-            .ok();
+            });
+        if spawned.is_err() {
+            initializing.store(false, Ordering::Relaxed);
+        }
     }
 
     pub fn reference(project_root: Option<PathBuf>) -> Self {
@@ -756,6 +776,7 @@ impl SharedState {
             onec_connections: Default::default(),
             debug_session: Arc::new(Mutex::new(None)),
             search_engine: Arc::clone(&reference_search.engine),
+            workspace_search_initializing: Arc::new(AtomicBool::new(false)),
             index_progress: Arc::clone(&reference_search.progress),
             semantic_runtime: Arc::clone(&reference_search.semantic_runtime),
             overlay_warmup: Arc::new(Mutex::new(OverlayWarmupState::Pending)),
@@ -780,6 +801,7 @@ impl SharedState {
             onec_connections: Default::default(),
             debug_session: Arc::new(Mutex::new(None)),
             search_engine: Arc::new(Mutex::new(None)),
+            workspace_search_initializing: Arc::new(AtomicBool::new(false)),
             index_progress: IndexProgress::new(),
             semantic_runtime: Arc::new(Mutex::new(SemanticRuntimeStatus::Disabled)),
             overlay_warmup: Arc::new(Mutex::new(OverlayWarmupState::Pending)),
@@ -2199,6 +2221,7 @@ mod tests {
 
         SharedState::spawn_workspace_search_init(
             Arc::new(Mutex::new(None)),
+            Arc::new(std::sync::atomic::AtomicBool::new(true)),
             IndexProgress::new(),
             Arc::new(Mutex::new(SemanticRuntimeStatus::Disabled)),
             workspace.clone(),
@@ -2261,6 +2284,7 @@ mod tests {
     ) {
         SharedState::spawn_workspace_search_init(
             engine,
+            Arc::new(std::sync::atomic::AtomicBool::new(true)),
             IndexProgress::new(),
             Arc::new(Mutex::new(SemanticRuntimeStatus::Disabled)),
             workspace,

--- a/crates/mcp-server/src/state/mod.rs
+++ b/crates/mcp-server/src/state/mod.rs
@@ -15,6 +15,7 @@ use bsl_search::IndexProgress;
 use onec_client::Client as OnecClient;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 pub(crate) use types::{
@@ -67,6 +68,7 @@ pub struct SharedState {
     onec_connections: BTreeMap<String, OnecConnection>,
     debug_session: Arc<Mutex<Option<bsl_debug::session::DebugSession>>>,
     search_engine: SharedSearchEngine,
+    workspace_search_initializing: Arc<AtomicBool>,
     index_progress: Arc<IndexProgress>,
     semantic_runtime: Arc<Mutex<SemanticRuntimeStatus>>,
     /// Outcome of the startup overlay warmup, so `search status` can distinguish "no local
@@ -213,6 +215,18 @@ impl SharedState {
 
     pub(crate) fn owns_caches(&self) -> bool {
         self.workspace_lease.owns_caches()
+    }
+
+    pub(crate) fn background_work_active(&self) -> bool {
+        self.workspace_search_initializing.load(Ordering::Relaxed)
+            || self.reference_search.loading()
+            || self.index_progress.is_active()
+            || self.semantic_runtime.try_lock().map_or(true, |status| {
+                matches!(
+                    *status,
+                    SemanticRuntimeStatus::Indexing | SemanticRuntimeStatus::OverlaySyncing
+                )
+            })
     }
 
     /// Start building the diagnostics resident now instead of on the first tool call.
@@ -580,5 +594,21 @@ mod standalone_extension_tests {
 
         std::fs::write(&config, "[source]\nroot = \"cf\"\nextensions = []\n").unwrap();
         assert!(state.standalone_extension_notice().is_none(), "and must go away again");
+    }
+}
+
+#[cfg(test)]
+mod background_lifetime_tests {
+    use super::SharedState;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn active_indexing_keeps_the_backend_alive() {
+        let state = SharedState::shared();
+        assert!(!state.background_work_active());
+
+        state.index_progress().active.store(true, Ordering::Relaxed);
+
+        assert!(state.background_work_active());
     }
 }

--- a/crates/mcp-server/tests/broker.rs
+++ b/crates/mcp-server/tests/broker.rs
@@ -20,7 +20,7 @@ use rmcp::ServiceExt;
 use tempfile::TempDir;
 
 fn reference_server() -> McpServer {
-    McpServer::new(McpProfile::Reference, SharedState::reference(None))
+    McpServer::new(McpProfile::Reference, SharedState::shared())
 }
 
 #[cfg(any(unix, windows))]


### PR DESCRIPTION
## Что изменено

- broker не отсчитывает idle TTL, пока workspace/reference search ещё инициализируется;
- активные indexing, embedding и overlay sync также удерживают backend;
- проверки фоновой активности в daemon loop не блокируются;
- флаг workspace-init снимается на любом выходе worker thread.

## Зачем

Фоновая инициализация принадлежит backend, а не transport session. На больших workspace она может пережить idle TTL; раньше daemon завершал процесс, и следующему клиенту приходилось начинать индексирование заново.

## Проверка

- `cargo test -p mcp-server state::background_lifetime_tests::active_indexing_keeps_the_backend_alive -- --exact`
- `cargo test -p mcp-server --test broker backend_idles_out_after_ttl -- --exact`
- `cargo test -p mcp-server --test broker backend_survives_client_disconnect_and_stays_reusable -- --exact`
- `cargo clippy -p mcp-server --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
