### PR TITLE
fix(mcp): enforce workspace lease operation profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,18 @@ jobs:
       - run: cargo clippy --all-targets --all-features
       - name: Portable workspace lease profiles
         run: |
-          cargo test -p mcp-server workspace_lease::tests::contention_unclaimed_and_missing_are_transient -- --exact
-          cargo test -p mcp-server workspace_lease::tests::release_signal_precedes_lifecycle_wait -- --exact
-          cargo test -p mcp-server graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement -- --exact
-          cargo test -p mcp-server tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease -- --exact
-          cargo test -p mcp-server tools::search::tests::all_search_modes_are_resident_only_under_held_lease -- --exact
-          cargo test -p mcp-server tests::all_status_requests_are_cached_under_held_lease -- --exact
+          set -euo pipefail
+          run_exact() {
+            output=$(cargo test -p mcp-server --lib "$1" -- --exact 2>&1)
+            printf '%s\n' "$output"
+            grep -Eq 'test result: ok\. [1-9][0-9]* passed' <<<"$output"
+          }
+          run_exact workspace_lease::tests::contention_unclaimed_and_missing_are_transient
+          run_exact workspace_lease::tests::a_throttled_checkpoint_still_reports_a_release
+          run_exact graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement
+          run_exact tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease
+          run_exact tools::search::tests::all_search_modes_are_resident_only_under_held_lease
+          run_exact tests::all_status_requests_are_cached_under_held_lease
       - run: cargo test --all --no-fail-fast
 
   windows-mcp:
@@ -72,8 +78,7 @@ jobs:
           cargo test -p mcp-server state::bootstrap::tests::startup_metadata_fence_stops_after_takeover &&
           cargo test -p mcp-server state::bootstrap::tests::startup_ingest_fence_does_not_repeat_preparation &&
           cargo test -p mcp-server state::bootstrap::tests::superseded_bootstrap_stops_mutating &&
-          cargo test -p mcp-server state::sync::tests::superseded_daemon_cannot_mutate_shared_search &&
-          cargo test -p mcp-server search_code_does_not_write_after_supersession
+          cargo test -p mcp-server state::sync::tests::superseded_daemon_cannot_mutate_shared_search
       - name: Terminal graph snapshot lifecycle
         run: >-
           cargo test -p mcp-server graph::state::tests::superseded_graph_never_adopts_or_reloads &&
@@ -108,13 +113,20 @@ jobs:
           cargo test -p mcp-server graph_supersession_contract::resolve_names_misses_immediately_when_preopened_handles_are_busy -- --exact &&
           cargo test -p mcp-server graph_supersession_contract::symbol_info_misses_immediately_when_preopened_handles_are_busy -- --exact
       - name: Portable workspace lease profiles
-        run: >-
-          cargo test -p mcp-server workspace_lease::tests::contention_unclaimed_and_missing_are_transient -- --exact &&
-          cargo test -p mcp-server workspace_lease::tests::release_signal_precedes_lifecycle_wait -- --exact &&
-          cargo test -p mcp-server graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement -- --exact &&
-          cargo test -p mcp-server tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease -- --exact &&
-          cargo test -p mcp-server tools::search::tests::all_search_modes_are_resident_only_under_held_lease -- --exact &&
-          cargo test -p mcp-server tests::all_status_requests_are_cached_under_held_lease -- --exact
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_exact() {
+            output=$(cargo test -p mcp-server --lib "$1" -- --exact 2>&1)
+            printf '%s\n' "$output"
+            grep -Eq 'test result: ok\. [1-9][0-9]* passed' <<<"$output"
+          }
+          run_exact workspace_lease::tests::contention_unclaimed_and_missing_are_transient
+          run_exact workspace_lease::tests::a_throttled_checkpoint_still_reports_a_release
+          run_exact graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement
+          run_exact tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease
+          run_exact tools::search::tests::all_search_modes_are_resident_only_under_held_lease
+          run_exact tests::all_status_requests_are_cached_under_held_lease
 
   partitioned-baseline-scale:
     name: Partitioned baseline 1.6M release gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features
+      - name: Portable workspace lease profiles
+        run: |
+          cargo test -p mcp-server workspace_lease::tests::contention_unclaimed_and_missing_are_transient -- --exact
+          cargo test -p mcp-server workspace_lease::tests::release_signal_precedes_lifecycle_wait -- --exact
+          cargo test -p mcp-server graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement -- --exact
+          cargo test -p mcp-server tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease -- --exact
+          cargo test -p mcp-server tools::search::tests::all_search_modes_are_resident_only_under_held_lease -- --exact
+          cargo test -p mcp-server tests::all_status_requests_are_cached_under_held_lease -- --exact
       - run: cargo test --all --no-fail-fast
 
   windows-mcp:
@@ -97,6 +105,14 @@ jobs:
           cargo test -p mcp-server graph_supersession_contract::graph_handler_misses_immediately_when_preopened_handles_are_busy -- --exact &&
           cargo test -p mcp-server graph_supersession_contract::resolve_names_misses_immediately_when_preopened_handles_are_busy -- --exact &&
           cargo test -p mcp-server graph_supersession_contract::symbol_info_misses_immediately_when_preopened_handles_are_busy -- --exact
+      - name: Portable workspace lease profiles
+        run: >-
+          cargo test -p mcp-server workspace_lease::tests::contention_unclaimed_and_missing_are_transient -- --exact &&
+          cargo test -p mcp-server workspace_lease::tests::release_signal_precedes_lifecycle_wait -- --exact &&
+          cargo test -p mcp-server graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement -- --exact &&
+          cargo test -p mcp-server tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease -- --exact &&
+          cargo test -p mcp-server tools::search::tests::all_search_modes_are_resident_only_under_held_lease -- --exact &&
+          cargo test -p mcp-server tests::all_status_requests_are_cached_under_held_lease -- --exact
 
   partitioned-baseline-scale:
     name: Partitioned baseline 1.6M release gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
@@ -37,6 +35,11 @@ jobs:
           run_exact tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease
           run_exact tools::search::tests::all_search_modes_are_resident_only_under_held_lease
           run_exact tests::all_status_requests_are_cached_under_held_lease
+          run_exact inventory::no_generic_or_unclassified_production_lease_callers
+          run_exact inventory::fence_callers_are_exactly_classified
+          run_exact inventory::request_paths_do_not_call_lease_or_mutation_helpers
+          run_exact inventory::production_prefix_handles_checkout_line_endings
+          run_exact state::embed::tests::prepared_index_survives_transient_swap_without_rebuild
       - run: cargo test --all --no-fail-fast
 
   windows-mcp:
@@ -127,6 +130,11 @@ jobs:
           run_exact tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease
           run_exact tools::search::tests::all_search_modes_are_resident_only_under_held_lease
           run_exact tests::all_status_requests_are_cached_under_held_lease
+          run_exact inventory::no_generic_or_unclassified_production_lease_callers
+          run_exact inventory::fence_callers_are_exactly_classified
+          run_exact inventory::request_paths_do_not_call_lease_or_mutation_helpers
+          run_exact inventory::production_prefix_handles_checkout_line_endings
+          run_exact state::embed::tests::prepared_index_survives_transient_swap_without_rebuild
 
   partitioned-baseline-scale:
     name: Partitioned baseline 1.6M release gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
         run: cargo test -p mcp-server --test http
       - name: Broker runtime tests
         run: cargo test -p mcp-server --test broker
+      - name: Name dictionary before graph publication
+        run: cargo test -p mcp-server --test name_dictionary
       - name: Superseded workspace lease lifecycle
         run: >-
           cargo test -p mcp-server workspace_lease::tests::observed_foreign_owner_is_permanent &&

--- a/crates/bsl-analyzer/tests/selective_diagnostics_baseline_lsp.rs
+++ b/crates/bsl-analyzer/tests/selective_diagnostics_baseline_lsp.rs
@@ -122,9 +122,17 @@ fn selective_lsp_enabled_error_is_fail_visible_and_recovers() {
         .to_owned();
     let object = root.join("baselines").join(&relative);
     let valid = std::fs::read(&object).unwrap();
+    let directory =
+        project_model::ManagedBaselineDirectory::open(root, "baselines", false).unwrap();
+    // Publish one complete state: truncate/write can expose an empty file with a
+    // different error epoch between two identical corrupt snapshots.
+    let replace_object = |contents: &[u8]| {
+        directory.create_file_new("replacement.tmp").unwrap().write_all(contents).unwrap();
+        directory.replace_file("replacement.tmp", &relative).unwrap();
+    };
     // Broken ONCE: the write may land before the watcher is armed and raise no event, and
     // the server has to notice it anyway, the next time the client asks it for anything.
-    std::fs::write(&object, b"{broken").unwrap();
+    replace_object(b"{broken");
     let deadline = std::time::Instant::now() + Duration::from_secs(60);
     let main_uri = lsp_types::Url::from_file_path(root.join("src/cf/Main.bsl")).unwrap();
     let ext_uri = lsp_types::Url::from_file_path(root.join("src/cfe/Ext/Ext.bsl")).unwrap();
@@ -151,7 +159,7 @@ fn selective_lsp_enabled_error_is_fail_visible_and_recovers() {
         }
     }
 
-    std::fs::write(&object, b"{broken").unwrap();
+    replace_object(b"{broken");
     let duplicate = std::time::Instant::now() + Duration::from_millis(500);
     while std::time::Instant::now() < duplicate {
         match lsp.messages.recv_timeout(Duration::from_millis(50)) {
@@ -159,17 +167,15 @@ fn selective_lsp_enabled_error_is_fail_visible_and_recovers() {
                 message["method"] != "window/showMessage"
                     || !message["params"]["message"]
                         .as_str()
-                        .is_some_and(|message| message.contains("diagnostics baseline"))
+                        .is_some_and(|message| message.contains("diagnostics baseline")),
+                "unchanged baseline error was reported again: {message}"
             ),
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
 
-    let directory =
-        project_model::ManagedBaselineDirectory::open(root, "baselines", false).unwrap();
-    directory.create_file_new("replacement.tmp").unwrap().write_all(&valid).unwrap();
-    directory.replace_file("replacement.tmp", &relative).unwrap();
+    replace_object(&valid);
     let mut main_seen = false;
     let mut ext_seen = false;
     let repaired = std::time::Instant::now() + Duration::from_secs(60);
@@ -194,7 +200,7 @@ fn selective_lsp_enabled_error_is_fail_visible_and_recovers() {
         }
     }
 
-    std::fs::write(&object, b"{broken-again").unwrap();
+    replace_object(b"{broken-again");
     let again = std::time::Instant::now() + Duration::from_secs(60);
     let notified = loop {
         if let Some(message) = lsp.wait_for_within(Duration::from_secs(1), |message| {

--- a/crates/bsl-search/src/engine.rs
+++ b/crates/bsl-search/src/engine.rs
@@ -7,7 +7,8 @@ use crate::ports::{ModuleSnapshot, ModuleSnapshotSource, SnapshotCatalog, Snapsh
 use crate::publish::EmbeddingExecutionPolicy;
 use crate::resolver::{InMemoryResolvedViewResolver, ResolvedView};
 use crate::store::{
-    ContextRefreshMutation, Store, WorkspaceStoreTransition, WorkspaceTransitionFile,
+    ContextRefreshMutation, Store, WorkspaceDriftStoreOutcome, WorkspaceStoreTransition,
+    WorkspaceTransitionFile,
 };
 use crate::workspace_overlay::{
     lexical_hits, normalized_file_hash_for_indexed_documents, semantic_hits, BaselineHashMode,
@@ -122,7 +123,8 @@ pub struct ReferenceCollectionReplaceOutcome {
 pub enum FenceOutcome<T> {
     Applied(T),
     TransientRefusal,
-    Terminal,
+    Superseded,
+    Released,
 }
 
 #[doc(hidden)]
@@ -541,7 +543,7 @@ impl SearchEngine {
     pub fn new(db_path: &Path, config: SearchConfig) -> Result<Self, SearchError> {
         match Self::new_fenced(db_path, config, Self::permit_checkpointed_apply)? {
             FenceOutcome::Applied(engine) => Ok(engine),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all constructor fence cannot refuse")
             }
         }
@@ -567,7 +569,8 @@ impl SearchEngine {
         let store = match Self::open_store_fenced(db_path, &mut apply)? {
             FenceOutcome::Applied(store) => store,
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         };
         let dim = embedder_config.dim.unwrap_or(1024);
         let embedder = Embedder::new(embedder_config);
@@ -587,7 +590,8 @@ impl SearchEngine {
                 match persisted {
                     FenceOutcome::Applied(()) => prepared.finish(),
                     FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-                    FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+                    FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+                    FenceOutcome::Released => return Ok(FenceOutcome::Released),
                 }
             }
         }
@@ -597,7 +601,8 @@ impl SearchEngine {
         })? {
             FenceOutcome::Applied(()) => {}
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         }
 
         Ok(FenceOutcome::Applied(Self {
@@ -694,7 +699,8 @@ impl SearchEngine {
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }
                 FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-                FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+                FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+                FenceOutcome::Released => return Ok(FenceOutcome::Released),
             }
         }
     }
@@ -719,7 +725,8 @@ impl SearchEngine {
         };
         match apply(&mut erased) {
             FenceOutcome::TransientRefusal => Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => Ok(FenceOutcome::Released),
             FenceOutcome::Applied(Err(error)) => Err(error),
             FenceOutcome::Applied(Ok(())) => value.map(FenceOutcome::Applied).ok_or_else(|| {
                 SearchError::Index(
@@ -789,7 +796,8 @@ impl SearchEngine {
         };
         match apply(&mut erased) {
             FenceOutcome::TransientRefusal => Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => Ok(FenceOutcome::Released),
             FenceOutcome::Applied(Err(error)) => Err(error),
             FenceOutcome::Applied(Ok(())) => value.map(FenceOutcome::Applied).ok_or_else(|| {
                 SearchError::Index(
@@ -914,7 +922,7 @@ impl SearchEngine {
     pub fn fts_only(db_path: &Path) -> Result<Self, SearchError> {
         match Self::fts_only_fenced(db_path, Self::permit_checkpointed_apply)? {
             FenceOutcome::Applied(engine) => Ok(engine),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all constructor fence cannot refuse")
             }
         }
@@ -935,7 +943,8 @@ impl SearchEngine {
         let store = match Self::open_store_fenced(db_path, &mut apply)? {
             FenceOutcome::Applied(store) => store,
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         };
         let dim = 1024;
         let index = VectorIndex::new(dim)?;
@@ -946,7 +955,8 @@ impl SearchEngine {
         })? {
             FenceOutcome::Applied(()) => {}
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         }
 
         Ok(FenceOutcome::Applied(Self {
@@ -975,7 +985,7 @@ impl SearchEngine {
             Self::permit_checkpointed_apply(apply)
         })? {
             FenceOutcome::Applied(engine) => Ok(engine),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all constructor fence cannot refuse")
             }
         }
@@ -998,7 +1008,8 @@ impl SearchEngine {
         let store = match Self::open_store_fenced(db_path, &mut apply)? {
             FenceOutcome::Applied(store) => store,
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         };
         let dim = embedder_config.dim.unwrap_or(1024);
         let embedder = Embedder::new(embedder_config);
@@ -1010,7 +1021,8 @@ impl SearchEngine {
         })? {
             FenceOutcome::Applied(()) => {}
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         }
 
         Ok(FenceOutcome::Applied(Self {
@@ -1461,7 +1473,8 @@ impl SearchEngine {
         Ok(match completed {
             FenceOutcome::Applied(()) => FenceOutcome::Applied(index),
             FenceOutcome::TransientRefusal => FenceOutcome::TransientRefusal,
-            FenceOutcome::Terminal => FenceOutcome::Terminal,
+            FenceOutcome::Superseded => FenceOutcome::Superseded,
+            FenceOutcome::Released => FenceOutcome::Released,
         })
     }
 
@@ -1522,7 +1535,7 @@ impl SearchEngine {
         for batch in items.chunks(batch_size) {
             if should_continue.is_some_and(|keep_going| !keep_going()) {
                 let (_, data) = store.load_all_embeddings_with_generation(dim)?;
-                return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Terminal));
+                return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Released));
             }
             match Self::fenced_value_retrying(apply, || Ok(()), retry_transient)? {
                 FenceOutcome::Applied(()) => {}
@@ -1530,9 +1543,13 @@ impl SearchEngine {
                     let (_, data) = store.load_all_embeddings_with_generation(dim)?;
                     return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::TransientRefusal));
                 }
-                FenceOutcome::Terminal => {
+                FenceOutcome::Superseded => {
                     let (_, data) = store.load_all_embeddings_with_generation(dim)?;
-                    return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Terminal));
+                    return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Superseded));
+                }
+                FenceOutcome::Released => {
+                    let (_, data) = store.load_all_embeddings_with_generation(dim)?;
+                    return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Released));
                 }
             }
 
@@ -1561,9 +1578,13 @@ impl SearchEngine {
                     let (_, data) = store.load_all_embeddings_with_generation(dim)?;
                     return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::TransientRefusal));
                 }
-                FenceOutcome::Terminal => {
+                FenceOutcome::Superseded => {
                     let (_, data) = store.load_all_embeddings_with_generation(dim)?;
-                    return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Terminal));
+                    return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Superseded));
+                }
+                FenceOutcome::Released => {
+                    let (_, data) = store.load_all_embeddings_with_generation(dim)?;
+                    return Ok((VectorIndex::build(dim, &data)?, FenceOutcome::Released));
                 }
             }
         }
@@ -1622,7 +1643,7 @@ impl SearchEngine {
             // The sidecar is a shared artifact like any other; a caller that may no longer
             // write leaves it to whoever may.
             if should_continue.is_some_and(|keep_going| !keep_going()) {
-                return Ok((index, FenceOutcome::Terminal));
+                return Ok((index, FenceOutcome::Released));
             }
             let persisted = if let Some(mut prepared) =
                 Self::prepare_built(store, dim, Some(embedder), &index, generation)
@@ -1733,7 +1754,7 @@ impl SearchEngine {
             // Asked between batches, never inside one: a pass over a large configuration runs
             // for hours, and the caller's right to write may not outlive it.
             if should_continue.is_some_and(|keep_going| !keep_going()) {
-                stopped = Some(FenceOutcome::Terminal);
+                stopped = Some(FenceOutcome::Released);
                 break;
             }
             match result {
@@ -1745,8 +1766,12 @@ impl SearchEngine {
                             stopped = Some(FenceOutcome::TransientRefusal);
                             break;
                         }
-                        FenceOutcome::Terminal => {
-                            stopped = Some(FenceOutcome::Terminal);
+                        FenceOutcome::Superseded => {
+                            stopped = Some(FenceOutcome::Superseded);
+                            break;
+                        }
+                        FenceOutcome::Released => {
+                            stopped = Some(FenceOutcome::Released);
                             break;
                         }
                     }
@@ -1777,7 +1802,7 @@ impl SearchEngine {
         let stopped = stopped.or_else(|| {
             should_continue
                 .is_some_and(|keep_going| !keep_going())
-                .then_some(FenceOutcome::Terminal)
+                .then_some(FenceOutcome::Released)
         });
         if let Some(outcome) = stopped {
             // The vectors already written stay — they were written while the caller still had
@@ -1803,7 +1828,8 @@ impl SearchEngine {
         match persisted {
             FenceOutcome::Applied(()) => {}
             FenceOutcome::TransientRefusal => return Ok((index, FenceOutcome::TransientRefusal)),
-            FenceOutcome::Terminal => return Ok((index, FenceOutcome::Terminal)),
+            FenceOutcome::Superseded => return Ok((index, FenceOutcome::Superseded)),
+            FenceOutcome::Released => return Ok((index, FenceOutcome::Released)),
         }
 
         info!(embedded, errors, total_vectors = index.len(), "fused embedding complete");
@@ -2032,7 +2058,8 @@ impl SearchEngine {
                         FenceOutcome::TransientRefusal => {
                             return Ok(FenceOutcome::TransientRefusal)
                         }
-                        FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+                        FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+                        FenceOutcome::Released => return Ok(FenceOutcome::Released),
                     }
                     result.indexed += 1;
                 }
@@ -2052,7 +2079,7 @@ impl SearchEngine {
     pub fn index_directory_deferred(&mut self, root: &Path) -> Result<usize, SearchError> {
         match self.index_directory_deferred_fenced(root, Self::permit_checkpointed_apply)? {
             FenceOutcome::Applied(indexed) => Ok(indexed),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all ingest fence cannot refuse")
             }
         }
@@ -2075,7 +2102,8 @@ impl SearchEngine {
         let result = match self.ingest_boot_files_fenced(&bsl_files, true, &mut apply)? {
             FenceOutcome::Applied(result) => result,
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         };
         info!(
             indexed = result.indexed,
@@ -2088,7 +2116,7 @@ impl SearchEngine {
     pub fn index_directory_fts(&mut self, root: &Path) -> Result<usize, SearchError> {
         match self.index_directory_fts_fenced(root, Self::permit_checkpointed_apply)? {
             FenceOutcome::Applied(indexed) => Ok(indexed),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all ingest fence cannot refuse")
             }
         }
@@ -2110,7 +2138,8 @@ impl SearchEngine {
         Ok(match self.ingest_boot_files_fenced(&bsl_files, false, &mut apply)? {
             FenceOutcome::Applied(result) => FenceOutcome::Applied(result.indexed),
             FenceOutcome::TransientRefusal => FenceOutcome::TransientRefusal,
-            FenceOutcome::Terminal => FenceOutcome::Terminal,
+            FenceOutcome::Superseded => FenceOutcome::Superseded,
+            FenceOutcome::Released => FenceOutcome::Released,
         })
     }
 
@@ -2123,7 +2152,7 @@ impl SearchEngine {
     pub fn index_unindexed_roots_fts(&mut self) -> Result<usize, SearchError> {
         match self.index_unindexed_roots_fts_fenced(Self::permit_checkpointed_apply)? {
             FenceOutcome::Applied(indexed) => Ok(indexed),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all ingest fence cannot refuse")
             }
         }
@@ -2170,7 +2199,8 @@ impl SearchEngine {
         Ok(match self.ingest_boot_files_fenced(&files, false, &mut apply)? {
             FenceOutcome::Applied(result) => FenceOutcome::Applied(result.indexed),
             FenceOutcome::TransientRefusal => FenceOutcome::TransientRefusal,
-            FenceOutcome::Terminal => FenceOutcome::Terminal,
+            FenceOutcome::Superseded => FenceOutcome::Superseded,
+            FenceOutcome::Released => FenceOutcome::Released,
         })
     }
 
@@ -2892,6 +2922,57 @@ impl SearchEngine {
         Ok(())
     }
 
+    /// Apply one already-materialized drift slice. The host advances its cursors only after this
+    /// returns `Continue(Ok(_))`; cancellation rolls back every Store mutation in the slice.
+    pub fn apply_prepared_workspace_drift_batch(
+        &mut self,
+        dirty_keys: &[FileKey],
+        removed_keys: &[FileKey],
+        context_keys: &[FileKey],
+        checkpoint: &mut dyn FnMut() -> ControlFlow<()>,
+    ) -> ControlFlow<(), Result<usize, SearchError>> {
+        let rows = dirty_keys.len() + removed_keys.len() + context_keys.len();
+        if rows > WORKSPACE_APPLY_BATCH_ROWS {
+            return ControlFlow::Continue(Err(SearchError::Index(format!(
+                "workspace drift batch has {rows} rows; maximum is {WORKSPACE_APPLY_BATCH_ROWS}"
+            ))));
+        }
+        let mut cache = match self.workspace_overlay_cache.lock() {
+            Ok(cache) => cache,
+            Err(error) => {
+                return ControlFlow::Continue(Err(SearchError::Index(format!(
+                    "workspace overlay cache lock error: {error}"
+                ))));
+            }
+        };
+        let outcome =
+            match self.store.apply_workspace_drift_batch(removed_keys, context_keys, checkpoint) {
+                Ok(ControlFlow::Continue(outcome)) => outcome,
+                Ok(ControlFlow::Break(())) => return ControlFlow::Break(()),
+                Err(error) => return ControlFlow::Continue(Err(error)),
+            };
+        let WorkspaceDriftStoreOutcome { removed_chunk_ids, context_mark_seq } = outcome;
+        if let Some(seq) = context_mark_seq {
+            self.store.observe_committed_mark_seq(seq);
+        }
+        for chunk_id in removed_chunk_ids {
+            if let Err(error) = self.index.remove(chunk_id) {
+                tracing::warn!(chunk_id, "failed to evict a committed drift removal: {error}");
+            }
+        }
+        cache.enable_watcher_mode();
+        for key in dirty_keys {
+            cache.mark_dirty_path(key.clone());
+        }
+        for key in removed_keys {
+            cache.mark_dirty_path(key.clone());
+            // Local mode serves no baseline hits, so conservatively hiding a possible remote copy
+            // is correct without loading the workspace-sized manifest inside the publication.
+            cache.remove_known_deleted(key, true);
+        }
+        ControlFlow::Continue(Ok(removed_keys.len()))
+    }
+
     /// The store key of a workspace `.bsl` file, or `None` when it is not a
     /// `.bsl` or lies outside every registered root. Shared by the workspace
     /// point-update entry points.
@@ -3246,7 +3327,7 @@ impl SearchEngine {
             .reconcile_workspace_files_fenced(present_abs, |apply| FenceOutcome::Applied(apply()))?
         {
             FenceOutcome::Applied(removed) => Ok(removed),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all reconcile fence cannot refuse")
             }
         }
@@ -3299,7 +3380,8 @@ impl SearchEngine {
             match admitted {
                 FenceOutcome::Applied(()) => {}
                 FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-                FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+                FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+                FenceOutcome::Released => return Ok(FenceOutcome::Released),
             }
             match removal.expect("an admitted reconcile operation runs once") {
                 Ok(()) => batch.removed += 1,
@@ -3397,7 +3479,7 @@ impl SearchEngine {
             -> ControlFlow<(), Result<(), SearchError>>| {
             let mut checkpoint = || ControlFlow::Continue(());
             match operation(&mut checkpoint) {
-                ControlFlow::Break(()) => FenceOutcome::Terminal,
+                ControlFlow::Break(()) => FenceOutcome::Released,
                 ControlFlow::Continue(result) => FenceOutcome::Applied(result),
             }
         };
@@ -3405,7 +3487,7 @@ impl SearchEngine {
             self.refresh_dirty_contexts_fenced(provider, seq_bound, false, &mut apply)?;
         match outcome {
             FenceOutcome::Applied(()) => Ok(stats),
-            FenceOutcome::TransientRefusal | FenceOutcome::Terminal => {
+            FenceOutcome::TransientRefusal | FenceOutcome::Superseded | FenceOutcome::Released => {
                 unreachable!("the permit-all context refresh fence cannot refuse")
             }
         }
@@ -3503,7 +3585,8 @@ impl SearchEngine {
                 FenceOutcome::TransientRefusal => {
                     return Ok((stats, FenceOutcome::TransientRefusal));
                 }
-                FenceOutcome::Terminal => return Ok((stats, FenceOutcome::Terminal)),
+                FenceOutcome::Superseded => return Ok((stats, FenceOutcome::Superseded)),
+                FenceOutcome::Released => return Ok((stats, FenceOutcome::Released)),
             }
         }
         Ok((stats, FenceOutcome::Applied(())))
@@ -3515,11 +3598,32 @@ impl SearchEngine {
     /// claim — a file changed at the same stat during the local period would be suppressed by
     /// the inherited row after a switch back. Rows live only under the mode that wrote them.
     pub fn set_serves_external_baseline(&mut self, serves: bool) -> Result<(), SearchError> {
-        self.serves_external_baseline = serves;
-        if !serves {
-            self.store.clear_overlay_fingerprint_cache()?;
+        let mut checkpoint = || ControlFlow::Continue(());
+        match self.set_serves_external_baseline_checkpointed(serves, &mut checkpoint) {
+            ControlFlow::Continue(result) => result,
+            ControlFlow::Break(()) => unreachable!("permit-all checkpoint cannot cancel"),
         }
-        Ok(())
+    }
+
+    pub fn set_serves_external_baseline_checkpointed(
+        &mut self,
+        serves: bool,
+        checkpoint: &mut dyn FnMut() -> ControlFlow<()>,
+    ) -> ControlFlow<(), Result<(), SearchError>> {
+        if serves && self.serves_external_baseline {
+            return ControlFlow::Continue(Ok(()));
+        }
+        if !serves {
+            match self.store.clear_overlay_fingerprint_cache_checkpointed(checkpoint) {
+                Ok(ControlFlow::Continue(())) => {}
+                Ok(ControlFlow::Break(())) => return ControlFlow::Break(()),
+                Err(error) => return ControlFlow::Continue(Err(error)),
+            }
+        } else if checkpoint().is_break() {
+            return ControlFlow::Break(());
+        }
+        self.serves_external_baseline = serves;
+        ControlFlow::Continue(Ok(()))
     }
 
     /// The manifest fingerprints IF this engine serves an external baseline, `None` otherwise.
@@ -3822,7 +3926,8 @@ impl SearchEngine {
         )? {
             FenceOutcome::Applied(embeddings) => embeddings,
             FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-            FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+            FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+            FenceOutcome::Released => return Ok(FenceOutcome::Released),
         };
 
         // Include the warm-reused vectors for the plan's chunks in the published set so Phase C
@@ -3871,12 +3976,13 @@ impl SearchEngine {
             // vectors to the shared store, and a caller that lost the workspace lease must
             // stop writing over the new owner's rows.
             if !should_continue() {
-                return Ok(FenceOutcome::Terminal);
+                return Ok(FenceOutcome::Released);
             }
             match Self::fenced_value_retrying(apply, || Ok(()), retry_transient)? {
                 FenceOutcome::Applied(()) => {}
                 FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-                FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+                FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+                FenceOutcome::Released => return Ok(FenceOutcome::Released),
             }
             let inputs: Vec<&str> = batch.iter().map(|(_, input)| input.as_str()).collect();
             let embeddings = embedder.embed_batch_interactive(&inputs)?;
@@ -3889,7 +3995,7 @@ impl SearchEngine {
             // Re-checked AFTER the embed round-trip too: the stop signal may have changed while
             // the request was in flight. The actual SQLite save is separately fenced below.
             if !should_continue() {
-                return Ok(FenceOutcome::Terminal);
+                return Ok(FenceOutcome::Released);
             }
             // Persist to the standalone store (NOT the live engine) so partial progress survives
             // a mid-pass failure. The callback holds the host ownership barrier for this one
@@ -3909,7 +4015,8 @@ impl SearchEngine {
             match admitted {
                 FenceOutcome::Applied(()) => {}
                 FenceOutcome::TransientRefusal => return Ok(FenceOutcome::TransientRefusal),
-                FenceOutcome::Terminal => return Ok(FenceOutcome::Terminal),
+                FenceOutcome::Superseded => return Ok(FenceOutcome::Superseded),
+                FenceOutcome::Released => return Ok(FenceOutcome::Released),
             }
         }
 
@@ -4799,6 +4906,128 @@ mod tests {
     use std::ops::ControlFlow;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
+
+    fn baseline_manifest(snapshot: &str, rows: usize) -> crate::WorkspaceBaselineManifest {
+        crate::WorkspaceBaselineManifest {
+            snapshot_id: snapshot.to_owned(),
+            snapshot_fingerprint: Some(format!("{snapshot}-fingerprint")),
+            files: (0..rows)
+                .map(|index| crate::BaselineManifestFile {
+                    collection: "code".to_owned(),
+                    root_id: CONFIGURATION_ROOT_ID.to_owned(),
+                    path: format!("File{index}.bsl"),
+                    file_fingerprint: format!("fingerprint-{index}"),
+                    document_count: 1,
+                    file_object_id: format!("object-{index}"),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn manifest_and_fingerprint_transitions_checkpoint_and_rollback() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("search.db");
+        let mut engine = SearchEngine::fts_only(&db_path).unwrap();
+        let original = baseline_manifest("original", 1);
+        engine.store().save_baseline_manifest(&original).unwrap();
+
+        let replacement = baseline_manifest("replacement", WORKSPACE_APPLY_BATCH_ROWS + 1);
+        let mut checkpoints = 0;
+        let interrupted = engine
+            .store()
+            .save_baseline_manifest_checkpointed(&replacement, &mut || {
+                checkpoints += 1;
+                if checkpoints == 2 {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .unwrap();
+        assert!(interrupted.is_break());
+        assert_eq!(
+            engine.store().load_baseline_manifest().unwrap().unwrap().snapshot_id,
+            "original"
+        );
+
+        engine.store().save_baseline_manifest(&replacement).unwrap();
+        checkpoints = 0;
+        let interrupted = engine
+            .store()
+            .clear_baseline_manifest_checkpointed(&mut || {
+                checkpoints += 1;
+                if checkpoints == 2 {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .unwrap();
+        assert!(interrupted.is_break());
+        assert_eq!(
+            engine.store().load_coherent_baseline_manifest().unwrap().unwrap().snapshot_id,
+            "replacement"
+        );
+
+        engine.set_serves_external_baseline(true).unwrap();
+        let fingerprints = (0..=WORKSPACE_APPLY_BATCH_ROWS)
+            .map(|index| {
+                (
+                    FileKey::configuration(format!("File{index}.bsl")),
+                    crate::store::PersistedFingerprint {
+                        file_size: index as u64,
+                        file_mtime_secs: index as i64,
+                        file_mtime_nanos: 0,
+                        content_fingerprint: format!("content-{index}"),
+                        canonical: format!("canonical-{index}"),
+                    },
+                )
+            })
+            .collect();
+        engine.store().save_overlay_fingerprint_cache("replacement", &fingerprints).unwrap();
+        checkpoints = 0;
+        let interrupted = engine.set_serves_external_baseline_checkpointed(false, &mut || {
+            checkpoints += 1;
+            if checkpoints == 2 {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        });
+        assert!(interrupted.is_break());
+        assert!(engine.serves_external_baseline);
+        assert_eq!(engine.store().overlay_fingerprint_keys().unwrap().len(), fingerprints.len());
+    }
+
+    #[test]
+    fn prepared_drift_batch_rolls_back_owner_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = SearchEngine::fts_only(&dir.path().join("search.db")).unwrap();
+        let removed = FileKey::configuration("Removed.bsl");
+        let context = FileKey::configuration("Context.bsl");
+        let chunks = code_chunk::Chunker::chunk("Процедура Тест()\nКонецПроцедуры");
+        engine.ingest_fused_file(&removed, b"hash", &chunks, &vec![None; chunks.len()]).unwrap();
+        let mut checkpoints = 0;
+        let outcome = engine.apply_prepared_workspace_drift_batch(
+            &[],
+            std::slice::from_ref(&removed),
+            std::slice::from_ref(&context),
+            &mut || {
+                checkpoints += 1;
+                if checkpoints == 2 {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            },
+        );
+        assert!(outcome.is_break());
+        assert!(engine.store().file_hash(&removed.root_id, &removed.path).unwrap().is_some());
+        assert!(!engine.store().overlay_tombstone_paths("code").unwrap().contains(&removed));
+        assert!(!engine.context_dirty_paths("code").unwrap().contains(&context));
+        assert!(engine.workspace_overlay_dirty_paths().unwrap().is_empty());
+    }
     use tempfile::tempdir;
 
     #[test]
@@ -4854,7 +5083,7 @@ mod tests {
                 ControlFlow::Break(())
             };
             match operation(&mut checkpoint) {
-                ControlFlow::Break(()) => FenceOutcome::Terminal,
+                ControlFlow::Break(()) => FenceOutcome::Released,
                 ControlFlow::Continue(result) => FenceOutcome::Applied(result),
             }
         };
@@ -4877,7 +5106,7 @@ mod tests {
         })
         .unwrap();
 
-        assert!(matches!(outcome, FenceOutcome::Terminal));
+        assert!(matches!(outcome, FenceOutcome::Released));
         assert_eq!(admissions, 1);
         assert_eq!(checkpoints, 1);
         assert_eq!(
@@ -5079,11 +5308,11 @@ mod tests {
                 if calls.get() == 1 {
                     run_apply(apply)
                 } else {
-                    FenceOutcome::Terminal
+                    FenceOutcome::Superseded
                 }
             })
             .unwrap();
-        assert!(matches!(overlay, FenceOutcome::Terminal));
+        assert!(matches!(overlay, FenceOutcome::Superseded));
         assert_eq!(calls.get(), 2);
         assert_eq!(Store::open_existing(&refused_fts).unwrap().fts_count().unwrap(), 0);
 
@@ -5365,7 +5594,7 @@ mod tests {
                 |operation| FenceOutcome::Applied(operation()),
             )
             .unwrap(),
-            FenceOutcome::Terminal
+            FenceOutcome::Released
         ));
         assert_eq!(
             SearchEngine::embed_pending_chunks_standalone(&wrapper, &config, None, Some(&stop),)
@@ -5519,13 +5748,13 @@ mod tests {
                 if calls < 5 {
                     FenceOutcome::Applied(operation())
                 } else {
-                    FenceOutcome::Terminal
+                    FenceOutcome::Superseded
                 }
             },
         )
         .unwrap();
         #[cfg(not(windows))]
-        assert!(matches!(result, FenceOutcome::Terminal));
+        assert!(matches!(result, FenceOutcome::Superseded));
         #[cfg(windows)]
         assert!(matches!(result, FenceOutcome::Applied(_)));
         assert_eq!(calls, if cfg!(windows) { 4 } else { 5 });
@@ -6322,7 +6551,7 @@ mod tests {
                     "the refreshed heartbeat keeps the live owner admissible"
                 );
                 if admissions == 2 {
-                    return FenceOutcome::Terminal;
+                    return FenceOutcome::Released;
                 }
                 let mut checkpoint = || {
                     checkpoints += 1;
@@ -6331,14 +6560,14 @@ mod tests {
                     ControlFlow::Continue(())
                 };
                 match operation(&mut checkpoint) {
-                    ControlFlow::Break(()) => FenceOutcome::Terminal,
+                    ControlFlow::Break(()) => FenceOutcome::Released,
                     ControlFlow::Continue(result) => FenceOutcome::Applied(result),
                 }
             };
         let (partial, outcome) = engine
             .refresh_dirty_contexts_fenced(&NewContext, i64::MAX, false, &mut stop_before_second)
             .unwrap();
-        assert!(matches!(outcome, FenceOutcome::Terminal));
+        assert!(matches!(outcome, FenceOutcome::Released));
         assert_eq!(admissions, 2, "65 chunk writes require a second fence");
         assert_eq!(checkpoints, 2, "the committed batch heartbeats before and after its write");
         assert!(virtual_now > VIRTUAL_STALE_AFTER, "the virtual refresh exceeds stale interval");
@@ -6365,7 +6594,7 @@ mod tests {
             retry_admissions += 1;
             let mut checkpoint = || ControlFlow::Continue(());
             match operation(&mut checkpoint) {
-                ControlFlow::Break(()) => FenceOutcome::Terminal,
+                ControlFlow::Break(()) => FenceOutcome::Released,
                 ControlFlow::Continue(result) => FenceOutcome::Applied(result),
             }
         };
@@ -8897,7 +9126,7 @@ mod tests {
                 let mut checkpoint = || ControlFlow::Continue(());
                 match operation(&mut checkpoint) {
                     ControlFlow::Continue(value) => FenceOutcome::Applied(value),
-                    ControlFlow::Break(()) => FenceOutcome::Terminal,
+                    ControlFlow::Break(()) => FenceOutcome::Released,
                 }
             };
             SearchEngine::open_store_fenced(&db_path, &mut apply).unwrap()
@@ -8934,7 +9163,7 @@ mod tests {
                     let mut checkpoint = || ControlFlow::Continue(());
                     match operation(&mut checkpoint) {
                         ControlFlow::Continue(result) => FenceOutcome::Applied(result),
-                        ControlFlow::Break(()) => FenceOutcome::Terminal,
+                        ControlFlow::Break(()) => FenceOutcome::Released,
                     }
                 };
                 SearchEngine::open_store_fenced(db_path, &mut apply).unwrap()

--- a/crates/bsl-search/src/store.rs
+++ b/crates/bsl-search/src/store.rs
@@ -46,6 +46,11 @@ pub(crate) enum ContextRefreshMutation {
     Clear { key: FileKey, seq_bound: i64 },
 }
 
+pub(crate) struct WorkspaceDriftStoreOutcome {
+    pub(crate) removed_chunk_ids: Vec<i64>,
+    pub(crate) context_mark_seq: Option<i64>,
+}
+
 /// The embeddings the vector index is built from (`(chunk_id, vector)` rows) paired with the
 /// `embedding_generation` they were read at, as one consistent snapshot.
 pub type EmbeddingsSnapshot = (i64, Vec<(i64, Vec<f32>)>);
@@ -1025,6 +1030,10 @@ impl Store {
         self.mark_seq.fetch_max(seq, Ordering::SeqCst);
     }
 
+    pub(crate) fn observe_committed_mark_seq(&self, seq: i64) {
+        self.observe_mark_seq(seq);
+    }
+
     /// The highest mark seq the database at `path` has issued to ANYONE.
     ///
     /// A store's own high-water only tracks the stamps it allocated, so it sits below anything
@@ -1269,6 +1278,81 @@ impl Store {
             Ok(()) => ControlFlow::Continue(Ok((marked, updated, cleared))),
             Err(error) => ControlFlow::Continue(Err(error.into())),
         }
+    }
+
+    pub(crate) fn apply_workspace_drift_batch(
+        &self,
+        removed: &[FileKey],
+        context: &[FileKey],
+        checkpoint: &mut dyn FnMut() -> ControlFlow<()>,
+    ) -> Result<ControlFlow<(), WorkspaceDriftStoreOutcome>, SearchError> {
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        let mut removed_chunk_ids = Vec::new();
+        let deleted_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .to_string();
+        for key in removed {
+            let mut stmt = tx.prepare(
+                "SELECT c.id FROM chunks c JOIN files f ON f.id = c.file_id
+                 WHERE f.collection = 'code' AND f.root_id = ?1 AND f.path = ?2",
+            )?;
+            removed_chunk_ids.extend(
+                stmt.query_map(params![key.root_id, key.path], |row| row.get::<_, i64>(0))?
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+            tx.execute(
+                "INSERT INTO overlay_tombstones (root_id, path, collection, deleted_at)
+                 VALUES (?1, ?2, 'code', ?3)
+                 ON CONFLICT(root_id, path) DO UPDATE SET collection = 'code', deleted_at = ?3",
+                params![key.root_id, key.path, deleted_at],
+            )?;
+            tx.execute(
+                "DELETE FROM overlay_fingerprint_cache WHERE root_id = ?1 AND path = ?2",
+                params![key.root_id, key.path],
+            )?;
+            tx.execute(
+                "DELETE FROM chunks_fts WHERE rowid IN (
+                     SELECT c.id FROM chunks c JOIN files f ON f.id = c.file_id
+                     WHERE f.collection = 'code' AND f.root_id = ?1 AND f.path = ?2
+                 )",
+                params![key.root_id, key.path],
+            )?;
+            tx.execute(
+                "DELETE FROM files WHERE collection = 'code' AND root_id = ?1 AND path = ?2",
+                params![key.root_id, key.path],
+            )?;
+        }
+        let context_mark_seq = if context.is_empty() {
+            None
+        } else {
+            let seq = Self::next_mark_seq(&tx)?;
+            let marked_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0);
+            let mut stmt = tx.prepare(
+                "INSERT INTO context_dirty (root_id, path, collection, marked_at, seq)
+                 VALUES (?1, ?2, 'code', ?3, ?4)
+                 ON CONFLICT(root_id, path, collection) DO UPDATE SET marked_at = ?3, seq = ?4",
+            )?;
+            for key in context {
+                stmt.execute(params![key.root_id, key.path, marked_at, seq])?;
+            }
+            Some(seq)
+        };
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
+        tx.commit()?;
+        Ok(ControlFlow::Continue(WorkspaceDriftStoreOutcome {
+            removed_chunk_ids,
+            context_mark_seq,
+        }))
     }
 
     pub fn insert_chunk(
@@ -2402,6 +2486,21 @@ impl Store {
         &self,
         manifest: &crate::WorkspaceBaselineManifest,
     ) -> Result<(), SearchError> {
+        let mut checkpoint = || ControlFlow::Continue(());
+        match self.save_baseline_manifest_checkpointed(manifest, &mut checkpoint)? {
+            ControlFlow::Continue(()) => Ok(()),
+            ControlFlow::Break(()) => unreachable!("permit-all checkpoint cannot cancel"),
+        }
+    }
+
+    pub fn save_baseline_manifest_checkpointed(
+        &self,
+        manifest: &crate::WorkspaceBaselineManifest,
+        checkpoint: &mut dyn FnMut() -> ControlFlow<()>,
+    ) -> Result<ControlFlow<()>, SearchError> {
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
         let fetched_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -2422,24 +2521,45 @@ impl Store {
                 fetched_at.to_string()
             ],
         )?;
-        tx.execute("DELETE FROM baseline_manifest_files", [])?;
+        loop {
+            let deleted = tx.execute(
+                "DELETE FROM baseline_manifest_files WHERE rowid IN (
+                     SELECT rowid FROM baseline_manifest_files LIMIT ?1
+                 )",
+                params![crate::engine::WORKSPACE_APPLY_BATCH_ROWS as i64],
+            )?;
+            if deleted == crate::engine::WORKSPACE_APPLY_BATCH_ROWS && checkpoint().is_break() {
+                return Ok(ControlFlow::Break(()));
+            }
+            if deleted < crate::engine::WORKSPACE_APPLY_BATCH_ROWS {
+                break;
+            }
+        }
         {
             let mut stmt = tx.prepare(
                 "INSERT INTO baseline_manifest_files
                  (root_id, collection, path, file_fingerprint)
                  VALUES (?1, ?2, ?3, ?4)",
             )?;
-            for file in &manifest.files {
+            for (index, file) in manifest.files.iter().enumerate() {
                 stmt.execute(params![
                     file.root_id,
                     file.collection,
                     file.path,
                     file.file_fingerprint
                 ])?;
+                if (index + 1).is_multiple_of(crate::engine::WORKSPACE_APPLY_BATCH_ROWS)
+                    && checkpoint().is_break()
+                {
+                    return Ok(ControlFlow::Break(()));
+                }
             }
         }
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
         tx.commit()?;
-        Ok(())
+        Ok(ControlFlow::Continue(()))
     }
 
     pub fn load_baseline_manifest(&self) -> Result<Option<BaselineManifestRecord>, SearchError> {
@@ -2496,11 +2616,41 @@ impl Store {
     /// never be observable half-deleted: a surviving header over an emptied files table
     /// would read back as a valid-but-empty manifest. One transaction removes both.
     pub fn clear_baseline_manifest(&self) -> Result<(), SearchError> {
+        let mut checkpoint = || ControlFlow::Continue(());
+        match self.clear_baseline_manifest_checkpointed(&mut checkpoint)? {
+            ControlFlow::Continue(()) => Ok(()),
+            ControlFlow::Break(()) => unreachable!("permit-all checkpoint cannot cancel"),
+        }
+    }
+
+    pub fn clear_baseline_manifest_checkpointed(
+        &self,
+        checkpoint: &mut dyn FnMut() -> ControlFlow<()>,
+    ) -> Result<ControlFlow<()>, SearchError> {
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
         let tx = self.conn.unchecked_transaction()?;
-        tx.execute("DELETE FROM baseline_manifest_files", [])?;
+        loop {
+            let deleted = tx.execute(
+                "DELETE FROM baseline_manifest_files WHERE rowid IN (
+                     SELECT rowid FROM baseline_manifest_files LIMIT ?1
+                 )",
+                params![crate::engine::WORKSPACE_APPLY_BATCH_ROWS as i64],
+            )?;
+            if deleted == crate::engine::WORKSPACE_APPLY_BATCH_ROWS && checkpoint().is_break() {
+                return Ok(ControlFlow::Break(()));
+            }
+            if deleted < crate::engine::WORKSPACE_APPLY_BATCH_ROWS {
+                break;
+            }
+        }
         tx.execute("DELETE FROM baseline_manifest WHERE id = 1", [])?;
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
         tx.commit()?;
-        Ok(())
+        Ok(ControlFlow::Continue(()))
     }
 
     /// The persisted manifest header, but only when the `baseline_manifest_files` rows
@@ -2942,8 +3092,40 @@ impl Store {
     }
 
     pub fn clear_overlay_fingerprint_cache(&self) -> Result<(), SearchError> {
-        self.conn.execute("DELETE FROM overlay_fingerprint_cache", [])?;
-        Ok(())
+        let mut checkpoint = || ControlFlow::Continue(());
+        match self.clear_overlay_fingerprint_cache_checkpointed(&mut checkpoint)? {
+            ControlFlow::Continue(()) => Ok(()),
+            ControlFlow::Break(()) => unreachable!("permit-all checkpoint cannot cancel"),
+        }
+    }
+
+    pub fn clear_overlay_fingerprint_cache_checkpointed(
+        &self,
+        checkpoint: &mut dyn FnMut() -> ControlFlow<()>,
+    ) -> Result<ControlFlow<()>, SearchError> {
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        loop {
+            let deleted = tx.execute(
+                "DELETE FROM overlay_fingerprint_cache WHERE rowid IN (
+                     SELECT rowid FROM overlay_fingerprint_cache LIMIT ?1
+                 )",
+                params![crate::engine::WORKSPACE_APPLY_BATCH_ROWS as i64],
+            )?;
+            if deleted == crate::engine::WORKSPACE_APPLY_BATCH_ROWS && checkpoint().is_break() {
+                return Ok(ControlFlow::Break(()));
+            }
+            if deleted < crate::engine::WORKSPACE_APPLY_BATCH_ROWS {
+                break;
+            }
+        }
+        if checkpoint().is_break() {
+            return Ok(ControlFlow::Break(()));
+        }
+        tx.commit()?;
+        Ok(ControlFlow::Continue(()))
     }
 
     /// Drop exactly these keys' fingerprint rows, leaving every other row alone. A row asserts

--- a/crates/mcp-server/src/broker/daemon.rs
+++ b/crates/mcp-server/src/broker/daemon.rs
@@ -141,7 +141,7 @@ async fn serve(
     // fraction of the *shorter* grace so the exit lands close to the intended window, not
     // up to 2× late, even when a test drives a tiny TTL.
     let poll =
-        (orphan_grace.min(idle_ttl) / 4).clamp(Duration::from_millis(100), Duration::from_secs(15));
+        (orphan_grace.min(idle_ttl) / 4).clamp(Duration::from_millis(100), Duration::from_secs(1));
     let mut idle_since = Some(Instant::now());
     let mut ticker = interval(poll);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -166,12 +166,13 @@ async fn serve(
             }
             _ = ticker.tick() => {
                 sessions.retain(|h| !h.is_finished());
+                let superseded = server.superseded();
                 // Reset the idle clock while any session is connected; otherwise count down
                 // against the grace that fits the backend's history — the long `idle_ttl`
                 // once it has served real traffic, the short `orphan_grace` before then.
                 if active.load(Ordering::SeqCst) != 0 {
                     idle_since = None;
-                } else if server.superseded() {
+                } else if superseded {
                     // A newer generation owns this workspace's derived caches, so this backend
                     // is terminally unable to maintain them — a transient ownership refusal is
                     // not enough. The warm hold buys a reconnecting client nothing, and holding

--- a/crates/mcp-server/src/graph/build.rs
+++ b/crates/mcp-server/src/graph/build.rs
@@ -7,7 +7,7 @@ use bsl_search::SearchEngine;
 #[cfg(test)]
 use crate::cache::graph_db_path;
 use crate::graph_query::GraphDb;
-use crate::workspace_lease::LeaseOutcome;
+use crate::workspace_lease::{LeaseOperationError, LeaseOperationOutcome};
 
 #[cfg(test)]
 use super::input::GRAPH_SOURCE_ROOT;
@@ -26,7 +26,8 @@ pub(super) const GRAPH_BUILD_BATCH: usize = 500;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum LoadFailureReason {
     TransientRefusal,
-    Terminal,
+    Superseded,
+    Released,
     OperationError,
 }
 
@@ -55,24 +56,33 @@ impl std::fmt::Display for LoadFailure {
 impl std::error::Error for LoadFailure {}
 
 fn install_failure(
-    outcome: LeaseOutcome<Result<(), SnapshotInstallError>>,
+    outcome: LeaseOperationOutcome<(), SnapshotInstallError>,
 ) -> Result<(), LoadFailure> {
     match outcome {
-        LeaseOutcome::Applied(Ok(())) => Ok(()),
-        LeaseOutcome::Applied(Err(SnapshotInstallError::Changed)) => Err(LoadFailure::new(
-            LoadFailureReason::TransientRefusal,
+        LeaseOperationOutcome::Applied(()) => Ok(()),
+        LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+            SnapshotInstallError::Changed,
+        )) => Err(LoadFailure::new(
+            LoadFailureReason::OperationError,
             "graph path changed before the prepared snapshot pool could be installed",
         )),
-        LeaseOutcome::Applied(Err(SnapshotInstallError::Operation(message))) => {
-            Err(LoadFailure::new(LoadFailureReason::OperationError, message))
+        LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+            SnapshotInstallError::Operation(message),
+        )) => Err(LoadFailure::new(LoadFailureReason::OperationError, message)),
+        LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error)) => {
+            Err(LoadFailure::operation(error))
         }
-        LeaseOutcome::TransientRefusal => Err(LoadFailure::new(
+        LeaseOperationOutcome::TransientRefusal => Err(LoadFailure::new(
             LoadFailureReason::TransientRefusal,
             "workspace cache ownership was temporarily unavailable during graph snapshot install",
         )),
-        LeaseOutcome::Terminal => Err(LoadFailure::new(
-            LoadFailureReason::Terminal,
-            "workspace cache ownership ended before graph snapshot install",
+        LeaseOperationOutcome::Superseded => Err(LoadFailure::new(
+            LoadFailureReason::Superseded,
+            "workspace cache ownership was superseded before graph snapshot install",
+        )),
+        LeaseOperationOutcome::Released => Err(LoadFailure::new(
+            LoadFailureReason::Released,
+            "workspace cache ownership was released before graph snapshot install",
         )),
     }
 }
@@ -180,7 +190,10 @@ impl GraphState {
         if self.is_superseded() {
             self.record_load_failure(
                 is_reload,
-                LoadFailure::new(LoadFailureReason::Terminal, super::types::SUPERSEDED_GRAPH_ERROR),
+                LoadFailure::new(
+                    LoadFailureReason::Superseded,
+                    super::types::SUPERSEDED_GRAPH_ERROR,
+                ),
             );
             return;
         }
@@ -230,32 +243,6 @@ impl GraphState {
                     self.record_load_failure(is_reload, failure);
                     return;
                 }
-            }
-        }
-
-        // Everything below writes the shared graph database. Transient non-ownership may re-arm
-        // later; terminal supersession was rejected before either cache-adoption path above.
-        match self.lease.with_ownership_outcome(|| ()) {
-            LeaseOutcome::Applied(()) => {}
-            LeaseOutcome::TransientRefusal => {
-                self.record_load_failure(
-                    is_reload,
-                    LoadFailure::new(
-                        LoadFailureReason::TransientRefusal,
-                        "workspace cache ownership is temporarily unavailable; graph build deferred",
-                    ),
-                );
-                return;
-            }
-            LeaseOutcome::Terminal => {
-                self.record_load_failure(
-                    is_reload,
-                    LoadFailure::new(
-                        LoadFailureReason::Terminal,
-                        "workspace cache ownership ended before the graph build started",
-                    ),
-                );
-                return;
             }
         }
 
@@ -548,9 +535,9 @@ impl GraphState {
                     None,
                 )) {
                     return match error.reason {
-                        LoadFailureReason::TransientRefusal | LoadFailureReason::Terminal => {
-                            PublishAttemptOutcome::Refused(error)
-                        }
+                        LoadFailureReason::TransientRefusal
+                        | LoadFailureReason::Superseded
+                        | LoadFailureReason::Released => PublishAttemptOutcome::Refused(error),
                         LoadFailureReason::OperationError => PublishAttemptOutcome::FallBack,
                     };
                 }
@@ -568,9 +555,9 @@ impl GraphState {
                 tracing::warn!("incremental reload failed, falling back to full rebuild: {e}");
                 let _ = std::fs::remove_file(&tmp_path);
                 match e.reason {
-                    LoadFailureReason::TransientRefusal | LoadFailureReason::Terminal => {
-                        PublishAttemptOutcome::Refused(e)
-                    }
+                    LoadFailureReason::TransientRefusal
+                    | LoadFailureReason::Superseded
+                    | LoadFailureReason::Released => PublishAttemptOutcome::Refused(e),
                     LoadFailureReason::OperationError => PublishAttemptOutcome::FallBack,
                 }
             }
@@ -591,7 +578,7 @@ impl GraphState {
     ) -> PublishAttemptOutcome {
         if self.is_superseded() {
             return PublishAttemptOutcome::Refused(LoadFailure::new(
-                LoadFailureReason::Terminal,
+                LoadFailureReason::Superseded,
                 super::types::SUPERSEDED_GRAPH_ERROR,
             ));
         }
@@ -666,7 +653,7 @@ impl GraphState {
     ) -> PublishAttemptOutcome {
         if self.is_superseded() {
             return PublishAttemptOutcome::Refused(LoadFailure::new(
-                LoadFailureReason::Terminal,
+                LoadFailureReason::Superseded,
                 super::types::SUPERSEDED_GRAPH_ERROR,
             ));
         }
@@ -752,7 +739,15 @@ impl GraphState {
     /// build failures stay terminal.
     pub(super) fn record_load_failure(&self, is_reload: bool, failure: LoadFailure) {
         if failure.reason == LoadFailureReason::TransientRefusal {
-            self.withheld_build.store(true, std::sync::atomic::Ordering::SeqCst);
+            let mut retry = lock_recover(&self.graph_retry);
+            let window = retry.get_or_insert_with(|| {
+                crate::state::retry_window::RetryWindow::new(
+                    crate::state::retry_window::RetryOwner::Graph,
+                )
+            });
+            let _ = window.refused(std::time::Instant::now(), std::time::Duration::ZERO);
+        } else {
+            *lock_recover(&self.graph_retry) = None;
         }
         let mut inner = lock_recover(&self.inner);
         if is_reload {
@@ -919,9 +914,14 @@ fn publish_or_discard(
     tmp_path: &Path,
     out_path: &Path,
 ) -> Result<(), LoadFailure> {
-    match graph.lease.with_ownership_outcome(|| std::fs::rename(tmp_path, out_path)) {
-        LeaseOutcome::Applied(renamed) => renamed.map_err(LoadFailure::operation),
-        LeaseOutcome::TransientRefusal => {
+    match graph.lease.publish_short(&mut (), |_| std::fs::rename(tmp_path, out_path)) {
+        LeaseOperationOutcome::Applied(()) => Ok(()),
+        LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(error))
+        | LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error)) => {
+            let _ = std::fs::remove_file(tmp_path);
+            Err(LoadFailure::operation(error))
+        }
+        LeaseOperationOutcome::TransientRefusal => {
             let _ = std::fs::remove_file(tmp_path);
             Err(LoadFailure::new(
                 LoadFailureReason::TransientRefusal,
@@ -929,11 +929,18 @@ fn publish_or_discard(
                  when the graph build finished; the build was discarded instead of published",
             ))
         }
-        LeaseOutcome::Terminal => {
+        LeaseOperationOutcome::Superseded => {
             let _ = std::fs::remove_file(tmp_path);
             Err(LoadFailure::new(
-                LoadFailureReason::Terminal,
-                "workspace cache ownership ended before the graph build could be published",
+                LoadFailureReason::Superseded,
+                "workspace cache ownership was superseded before the graph build could be published",
+            ))
+        }
+        LeaseOperationOutcome::Released => {
+            let _ = std::fs::remove_file(tmp_path);
+            Err(LoadFailure::new(
+                LoadFailureReason::Released,
+                "workspace cache ownership was released before the graph build could be published",
             ))
         }
     }
@@ -1054,21 +1061,36 @@ impl ide::FusedChunkSink for FusedChunkWriter<'_> {
             {
                 continue;
             }
-            match self.lease.with_ownership_checkpointed(|checkpoint| {
+            match self.lease.publish_checkpointed(|checkpoint| {
                 self.engine.ingest_fused_file_checkpointed(&key, &hash, chunks, ctxs, checkpoint)
             }) {
-                LeaseOutcome::Applied(result) => result?,
-                LeaseOutcome::TransientRefusal => {
+                LeaseOperationOutcome::Applied(()) => {}
+                LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(error)) => {
+                    self.failure = Some(LoadFailure::operation(&error));
+                    return Err(error.into());
+                }
+                LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error)) => {
+                    self.failure = Some(LoadFailure::operation(error));
+                    return Err(std::io::Error::other("fused ingest stopped").into());
+                }
+                LeaseOperationOutcome::TransientRefusal => {
                     self.failure = Some(LoadFailure::new(
                         LoadFailureReason::TransientRefusal,
                         "workspace cache ownership was temporarily refused during fused ingest",
                     ));
                     return Err(std::io::Error::other("fused ingest stopped").into());
                 }
-                LeaseOutcome::Terminal => {
+                LeaseOperationOutcome::Superseded => {
                     self.failure = Some(LoadFailure::new(
-                        LoadFailureReason::Terminal,
-                        "workspace cache ownership ended during fused ingest",
+                        LoadFailureReason::Superseded,
+                        "workspace cache ownership was superseded during fused ingest",
+                    ));
+                    return Err(std::io::Error::other("fused ingest stopped").into());
+                }
+                LeaseOperationOutcome::Released => {
+                    self.failure = Some(LoadFailure::new(
+                        LoadFailureReason::Released,
+                        "workspace cache ownership was released during fused ingest",
                     ));
                     return Err(std::io::Error::other("fused ingest stopped").into());
                 }
@@ -1291,7 +1313,7 @@ mod tests {
         let error = graph
             .run_fused_cold_build(&mut engine, root, 0)
             .expect_err("takeover after the first file must stop fused ingest");
-        assert!(error.to_string().contains("ownership ended"), "{error}");
+        assert!(error.to_string().contains("ownership was superseded"), "{error}");
         assert!(lease.is_superseded(), "the second file's fence observes the new owner");
         assert_eq!(
             engine.store().all_files_in_collection("code").unwrap().len(),
@@ -1348,7 +1370,7 @@ mod tests {
     }
 
     #[test]
-    fn transient_publish_refusal_rearms_after_ownership_returns() {
+    fn original_transient_arms_withheld_build_until_trigger() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
@@ -1366,13 +1388,20 @@ mod tests {
 
         assert_eq!(error.reason, LoadFailureReason::TransientRefusal);
         graph.record_load_failure(false, error);
-        assert!(graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
-        assert_eq!(
-            lease.with_ownership_outcome(|| "ownership returned"),
-            LeaseOutcome::Applied("ownership returned")
-        );
+        assert!(lock_recover(&graph.graph_retry).is_some());
+        assert!(matches!(
+            lease.publish_short(&mut (), |_| Ok::<_, std::convert::Infallible>(
+                "ownership returned"
+            )),
+            LeaseOperationOutcome::Applied("ownership returned")
+        ));
         assert!(!temp.exists());
         assert!(!canonical.exists());
+
+        graph.ensure_loading();
+        assert!(!matches!(graph.status(), GraphStatus::Failed(_)));
+        wait_ready(&graph);
+        assert!(lock_recover(&graph.graph_retry).is_none());
     }
 
     #[test]
@@ -1395,9 +1424,9 @@ mod tests {
             &released_cache.root().join("released.db"),
         )
         .unwrap_err();
-        assert_eq!(released_error.reason, LoadFailureReason::Terminal);
+        assert_eq!(released_error.reason, LoadFailureReason::Released);
         released_graph.record_load_failure(false, released_error);
-        assert!(!released_graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&released_graph.graph_retry).is_none());
 
         let superseded_dir = tempfile::tempdir().unwrap();
         let superseded_cache =
@@ -1418,14 +1447,14 @@ mod tests {
             &superseded_cache.root().join("superseded.db"),
         )
         .unwrap_err();
-        assert_eq!(superseded_error.reason, LoadFailureReason::Terminal);
+        assert_eq!(superseded_error.reason, LoadFailureReason::Superseded);
         superseded_graph.record_load_failure(false, superseded_error);
-        assert!(!superseded_graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&superseded_graph.graph_retry).is_none());
         newer.release();
     }
 
     #[test]
-    fn rename_error_stays_operational_when_a_later_probe_would_refuse() {
+    fn operation_error_is_not_reclassified_by_later_probe() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
@@ -1442,7 +1471,7 @@ mod tests {
         graph.record_load_failure(false, error);
         drop(held);
 
-        assert!(!graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&graph.graph_retry).is_none());
     }
 
     /// Driven through the real cold-build entry point, not through the walk it happens
@@ -1500,7 +1529,12 @@ mod tests {
             GraphStatus::Ready { files: built.files },
             None,
         );
-        assert_eq!(fresh_install, LeaseOutcome::Applied(Err(SnapshotInstallError::Changed)));
+        assert!(matches!(
+            fresh_install,
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                SnapshotInstallError::Changed
+            ))
+        ));
         assert!(fresh.snapshot().is_none(), "fresh publish never becomes ready");
 
         let clean_dir = tempfile::tempdir().unwrap();
@@ -1514,7 +1548,7 @@ mod tests {
             panic!("clean adoption must preserve the final install refusal")
         };
         clean.record_load_failure(false, failure);
-        assert!(clean.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&clean.graph_retry).is_none());
         assert!(clean.snapshot().is_none(), "clean adoption never becomes ready");
 
         let stale_dir = tempfile::tempdir().unwrap();
@@ -1531,7 +1565,7 @@ mod tests {
             panic!("stale adoption must preserve the final install refusal")
         };
         stale.record_load_failure(false, failure);
-        assert!(stale.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&stale.graph_retry).is_none());
         assert!(stale.snapshot().is_none(), "stale adoption never becomes ready");
     }
 
@@ -1553,10 +1587,7 @@ mod tests {
 
         assert!(matches!(
             graph.try_incremental_reload(root, 2, 0),
-            PublishAttemptOutcome::Refused(LoadFailure {
-                reason: LoadFailureReason::TransientRefusal,
-                ..
-            })
+            PublishAttemptOutcome::FallBack
         ));
         assert_eq!(
             graph.snapshot().map(|snapshot| snapshot.generation),
@@ -1578,12 +1609,12 @@ mod tests {
         graph.run_load(false);
 
         assert!(matches!(graph.status(), GraphStatus::Ready { .. }));
-        assert!(!graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&graph.graph_retry).is_none());
         assert!(graph.snapshot().is_some(), "the invalid cache fell back to a real build");
     }
 
     #[test]
-    fn full_reload_install_refusal_keeps_the_old_snapshot_and_rearms() {
+    fn full_reload_install_failure_keeps_the_old_snapshot_without_transient_retry() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         sample_workspace(root);
@@ -1596,7 +1627,7 @@ mod tests {
         graph.run_load(true);
 
         assert_eq!(graph.snapshot().map(|snapshot| snapshot.generation), Some(1));
-        assert!(graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&graph.graph_retry).is_none());
         assert!(matches!(
             lock_recover(&graph.inner).published.as_ref().unwrap().reload,
             ReloadState::Failed(_)
@@ -2085,7 +2116,7 @@ mod tests {
         };
         assert_eq!(failure.reason, LoadFailureReason::TransientRefusal);
         graph.record_load_failure(true, failure);
-        assert!(graph.withheld_build.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(lock_recover(&graph.graph_retry).is_some());
     }
 
     /// A cached build whose fingerprint no longer matches the workspace (it moved

--- a/crates/mcp-server/src/graph/build.rs
+++ b/crates/mcp-server/src/graph/build.rs
@@ -63,7 +63,7 @@ fn install_failure(
         LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
             SnapshotInstallError::Changed,
         )) => Err(LoadFailure::new(
-            LoadFailureReason::OperationError,
+            LoadFailureReason::TransientRefusal,
             "graph path changed before the prepared snapshot pool could be installed",
         )),
         LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
@@ -735,19 +735,26 @@ impl GraphState {
     /// previous snapshot but flags `reload="failed"` so the agent sees it. A
     /// later drift check retries the reload (the throttle bounds the retry rate).
     ///
-    /// A transient ownership refusal is flagged for retry. Terminal supersession and genuine
-    /// build failures stay terminal.
+    /// A transient refusal keeps its retry budget. An operation error stops that obligation,
+    /// but fresh external work may start a new graph epoch; terminal lease outcomes never do.
     pub(super) fn record_load_failure(&self, is_reload: bool, failure: LoadFailure) {
-        if failure.reason == LoadFailureReason::TransientRefusal {
-            let mut retry = lock_recover(&self.graph_retry);
-            let window = retry.get_or_insert_with(|| {
-                crate::state::retry_window::RetryWindow::new(
-                    crate::state::retry_window::RetryOwner::Graph,
-                )
-            });
-            let _ = window.refused(std::time::Instant::now(), std::time::Duration::ZERO);
-        } else {
-            *lock_recover(&self.graph_retry) = None;
+        match failure.reason {
+            LoadFailureReason::TransientRefusal | LoadFailureReason::OperationError => {
+                let mut retry = lock_recover(&self.graph_retry);
+                let window = retry.get_or_insert_with(|| {
+                    crate::state::retry_window::RetryWindow::new(
+                        crate::state::retry_window::RetryOwner::Graph,
+                    )
+                });
+                if failure.reason == LoadFailureReason::TransientRefusal {
+                    let _ = window.refused(std::time::Instant::now(), std::time::Duration::ZERO);
+                } else {
+                    window.operation_error();
+                }
+            }
+            LoadFailureReason::Superseded | LoadFailureReason::Released => {
+                *lock_recover(&self.graph_retry) = None;
+            }
         }
         let mut inner = lock_recover(&self.inner);
         if is_reload {
@@ -1454,24 +1461,31 @@ mod tests {
     }
 
     #[test]
-    fn operation_error_is_not_reclassified_by_later_probe() {
+    fn operation_error_waits_for_fresh_work_without_losing_its_origin() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
+        sample_workspace(root);
         let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
         cache.ensure().unwrap();
         let lease = crate::workspace_lease::WorkspaceLease::claim_cache(&cache);
         let graph = GraphState::for_workspace_with_cache(root.to_path_buf(), cache.clone())
             .with_lease(lease.clone());
-        let missing = cache.root().join("missing.building");
-        let error = publish_or_discard(&graph, &missing, &cache.root().join("output.db"))
-            .expect_err("an admitted rename of a missing file is a real operation error");
+        let prepared = cache.root().join("prepared.building");
+        fs::write(&prepared, b"candidate").unwrap();
+        lease.fail_next_restamp_for_test();
+        let error = publish_or_discard(&graph, &prepared, &cache.root().join("output.db"))
+            .expect_err("a lease restamp failure is a real operation error");
         assert_eq!(error.reason, LoadFailureReason::OperationError);
 
         let held = lease.hold_file_lock_for_test();
         graph.record_load_failure(false, error);
         drop(held);
 
-        assert!(lock_recover(&graph.graph_retry).is_none());
+        assert!(lock_recover(&graph.graph_retry).is_some());
+        graph.ensure_loading();
+        assert!(matches!(graph.status(), GraphStatus::Failed(_)));
+        assert_eq!(graph.nudge_rebuild(), crate::graph::NudgeOutcome::LoadStarted);
+        wait_ready(&graph);
     }
 
     /// Driven through the real cold-build entry point, not through the walk it happens
@@ -1548,7 +1562,7 @@ mod tests {
             panic!("clean adoption must preserve the final install refusal")
         };
         clean.record_load_failure(false, failure);
-        assert!(lock_recover(&clean.graph_retry).is_none());
+        assert!(lock_recover(&clean.graph_retry).is_some());
         assert!(clean.snapshot().is_none(), "clean adoption never becomes ready");
 
         let stale_dir = tempfile::tempdir().unwrap();
@@ -1565,13 +1579,13 @@ mod tests {
             panic!("stale adoption must preserve the final install refusal")
         };
         stale.record_load_failure(false, failure);
-        assert!(lock_recover(&stale.graph_retry).is_none());
+        assert!(lock_recover(&stale.graph_retry).is_some());
         assert!(stale.snapshot().is_none(), "stale adoption never becomes ready");
     }
 
     #[cfg(not(windows))]
     #[test]
-    fn incremental_publication_propagates_final_install_refusal() {
+    fn incremental_publication_retries_changed_snapshot_install() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         sample_workspace(root);
@@ -1587,7 +1601,10 @@ mod tests {
 
         assert!(matches!(
             graph.try_incremental_reload(root, 2, 0),
-            PublishAttemptOutcome::FallBack
+            PublishAttemptOutcome::Refused(LoadFailure {
+                reason: LoadFailureReason::TransientRefusal,
+                ..
+            })
         ));
         assert_eq!(
             graph.snapshot().map(|snapshot| snapshot.generation),
@@ -1614,7 +1631,7 @@ mod tests {
     }
 
     #[test]
-    fn full_reload_install_failure_keeps_the_old_snapshot_without_transient_retry() {
+    fn full_reload_changed_install_keeps_the_old_snapshot_and_retries() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         sample_workspace(root);
@@ -1627,7 +1644,7 @@ mod tests {
         graph.run_load(true);
 
         assert_eq!(graph.snapshot().map(|snapshot| snapshot.generation), Some(1));
-        assert!(lock_recover(&graph.graph_retry).is_none());
+        assert!(lock_recover(&graph.graph_retry).is_some());
         assert!(matches!(
             lock_recover(&graph.inner).published.as_ref().unwrap().reload,
             ReloadState::Failed(_)

--- a/crates/mcp-server/src/graph/build.rs
+++ b/crates/mcp-server/src/graph/build.rs
@@ -23,6 +23,13 @@ use super::types::GraphStatus;
 /// while the resident method index resolves cross-batch calls.
 pub(super) const GRAPH_BUILD_BATCH: usize = 500;
 
+fn graph_build_path(path: &Path) -> PathBuf {
+    // Backend generations can overlap within one process as well as across processes.
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let build = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    path.with_extension(format!("db.building.{}.{build}", std::process::id()))
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum LoadFailureReason {
     TransientRefusal,
@@ -467,7 +474,7 @@ impl GraphState {
         // mirroring the full build's straddle detection: a write landing after the
         // pre-scan marks the snapshot stale.
         let fp_pre = super::scan::fingerprint_of(&pre.stats, &project.configs);
-        let tmp_path = db_path.with_extension(format!("db.building.{}", std::process::id()));
+        let tmp_path = graph_build_path(&db_path);
         let built_at = chrono::Utc::now().to_rfc3339();
         let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let summary = crate::graph_db::update_graph_database_bodies(
@@ -806,10 +813,7 @@ fn build_and_publish_scanned(
 ) -> Result<PublishedBuild, LoadFailure> {
     let fp_pre = super::scan::fingerprint_of(&pre.stats, &project.configs);
     let out_path = graph.graph_db_path().expect("workspace graph has cache layout");
-    // Pid-suffixed temp: two daemons over the same workspace (an old topology
-    // generation draining while a new one starts) must not interleave writes into
-    // one temp file — each builds its own and the atomic rename decides.
-    let tmp_path = out_path.with_extension(format!("db.building.{}", std::process::id()));
+    let tmp_path = graph_build_path(&out_path);
     if let Some(parent) = out_path.parent() {
         std::fs::create_dir_all(parent).map_err(LoadFailure::operation)?;
     }
@@ -1329,9 +1333,13 @@ mod tests {
         );
 
         let graph_path = cache.graph_db_path();
-        let tmp_path = graph_path.with_extension(format!("db.building.{}", std::process::id()));
         assert!(!graph_path.exists(), "the rejected build never replaces the canonical graph");
-        assert!(!tmp_path.exists(), "the rejected build removes only its current temp graph");
+        assert!(
+            fs::read_dir(graph_path.parent().unwrap()).unwrap().all(|entry| {
+                !entry.unwrap().file_name().to_string_lossy().starts_with("bsl-graph.db.building.")
+            }),
+            "the rejected build removes its temp graph",
+        );
 
         newer.lock().unwrap().take().unwrap().release();
     }
@@ -1357,7 +1365,10 @@ mod tests {
         let graph = GraphState::for_workspace_with_cache(root.to_path_buf(), cache.clone())
             .with_lease(old.clone());
         let canonical = cache.graph_db_path();
-        let temp = canonical.with_extension(format!("db.building.{}", std::process::id()));
+        let temp = graph_build_path(&canonical);
+        let other_temp = graph_build_path(&canonical);
+        assert_ne!(temp, other_temp, "same-process builds must not share a temporary database");
+        fs::write(&other_temp, b"other-build-in-progress").unwrap();
 
         fs::write(&canonical, b"new-owner-graph").unwrap();
         fs::write(&temp, b"old-daemon-graph").unwrap();
@@ -1369,11 +1380,20 @@ mod tests {
         publish_or_discard(&graph, &temp, &canonical).unwrap_err();
         assert_eq!(fs::read(&canonical).unwrap(), b"new-owner-graph");
         assert!(!temp.exists(), "normal refusal removes only this build's temp file");
+        assert_eq!(fs::read(&other_temp).unwrap(), b"other-build-in-progress");
 
         let mut sink = RefusingSink;
         assert!(build_and_publish_graph_file(root, 1, &graph, Some(&mut sink)).is_err());
         assert_eq!(fs::read(&canonical).unwrap(), b"new-owner-graph");
-        assert!(!temp.exists(), "fused failure before publication removes its temp file");
+        assert!(
+            fs::read_dir(canonical.parent().unwrap()).unwrap().all(|entry| {
+                let entry = entry.unwrap();
+                entry.path() == other_temp
+                    || !entry.file_name().to_string_lossy().starts_with("bsl-graph.db.building.")
+            }),
+            "fused failure removes its temp file and leaves the other build alone",
+        );
+        assert_eq!(fs::read(&other_temp).unwrap(), b"other-build-in-progress");
     }
 
     #[test]

--- a/crates/mcp-server/src/graph/mod.rs
+++ b/crates/mcp-server/src/graph/mod.rs
@@ -45,7 +45,7 @@ pub(crate) use scan::{classify_changes, file_fingerprint, FileStat, WorkspaceDif
     unused_imports,
     reason = "the stable graph facade preserves crate::graph snapshot paths while implementation stays private"
 )]
-pub(crate) use snapshot::{GraphSnapshot, PooledGraphDb};
+pub(crate) use snapshot::{BackgroundSnapshotError, GraphSnapshot, PooledGraphDb};
 pub(crate) use state::GraphState;
 #[allow(
     unused_imports,

--- a/crates/mcp-server/src/graph/snapshot.rs
+++ b/crates/mcp-server/src/graph/snapshot.rs
@@ -7,8 +7,12 @@ use std::time::{Instant, UNIX_EPOCH};
 use crate::change_hub::{ChangeEntry, ChangeKind};
 use crate::graph_query::GraphDb;
 
-use super::state::{lock_recover, GraphState, Published, ReloadState};
-use super::types::{Freshness, GraphStatus};
+#[cfg(test)]
+use super::state::ReloadState;
+use super::state::{lock_recover, GraphState, Published};
+#[cfg(test)]
+use super::types::Freshness;
+use super::types::GraphStatus;
 
 /// How often the query-path freshness fold must come from a real walk instead of the
 /// event-maintained map. Bounds how long a change the hub cannot observe can keep
@@ -43,6 +47,12 @@ pub(super) struct ScanCache {
 
 /// Every publication prepares this many independent read handles before becoming ready.
 pub(crate) const SNAPSHOT_POOL_CAP: usize = 4;
+
+#[derive(Debug)]
+pub(crate) enum BackgroundSnapshotError {
+    Changed,
+    Operation(anyhow::Error),
+}
 
 #[cfg(test)]
 type SnapshotOpenHook = Box<dyn FnOnce()>;
@@ -80,8 +90,8 @@ fn set_snapshot_checkout_hook(hook: SnapshotOpenHook) {
 /// A pooled idle read handle plus the freshness token it was opened under.
 pub(super) struct PooledSnapshotEntry {
     pub(super) generation: u64,
-    fingerprint: crate::graph_db::GraphFp,
-    force_stale: bool,
+    pub(super) fingerprint: crate::graph_db::GraphFp,
+    pub(super) force_stale: bool,
     db: GraphDb,
 }
 
@@ -231,8 +241,8 @@ fn classify_prepare_identity_error(error: std::io::Error) -> SnapshotPrepareErro
 pub(crate) struct GraphSnapshot {
     pub graph: PooledGraphDb,
     pub(super) generation: u64,
-    fingerprint: crate::graph_db::GraphFp,
-    force_stale: bool,
+    pub(super) fingerprint: crate::graph_db::GraphFp,
+    pub(super) force_stale: bool,
     /// Modules this artefact was built without being able to read. Makes `stale`
     /// true — the graph is missing their nodes and edges — WITHOUT making
     /// `wants_reload` true, since rebuilding cannot read them either.
@@ -358,18 +368,18 @@ impl GraphState {
     /// retried rather than silently dropped.
     pub(super) fn install_prepared_snapshot(
         &self,
-        prepared: PreparedSnapshotPool,
+        mut prepared: PreparedSnapshotPool,
         published: Published,
         status: GraphStatus,
         reload_obligation: Option<usize>,
-    ) -> crate::workspace_lease::LeaseOutcome<Result<(), SnapshotInstallError>> {
+    ) -> crate::workspace_lease::LeaseOperationOutcome<(), SnapshotInstallError> {
         #[cfg(test)]
         SNAPSHOT_OPEN_HOOK.with(|slot| {
             if let Some(hook) = slot.borrow_mut().take() {
                 hook();
             }
         });
-        self.lease.with_ownership_outcome(|| {
+        let outcome = self.lease.publish_short(&mut prepared, |prepared| {
             #[cfg(test)]
             if REFUSE_SNAPSHOT_INSTALL.with(|refuse| refuse.replace(false)) {
                 return Err(SnapshotInstallError::Changed);
@@ -405,14 +415,18 @@ impl GraphState {
             let mut inner = lock_recover(&self.inner);
             let mut pool = lock_recover(&self.snapshot_pool);
             pool.generation = published.generation;
-            pool.entries = prepared.entries;
+            pool.entries = std::mem::take(&mut prepared.entries);
             inner.published = Some(published);
             inner.status = status;
             if let Some(epoch) = reload_obligation {
                 self.complete_project_reload_through(epoch);
             }
             Ok(())
-        })
+        });
+        if matches!(&outcome, crate::workspace_lease::LeaseOperationOutcome::Applied(())) {
+            *lock_recover(&self.graph_retry) = None;
+        }
+        outcome
     }
 
     /// Snapshot the graph for a blocking query, if built. The returned
@@ -458,16 +472,17 @@ impl GraphState {
     /// Requests use [`Self::snapshot`] and never reach this fallback.
     pub(crate) fn snapshot_blocking(
         &self,
-    ) -> crate::workspace_lease::LeaseOutcome<anyhow::Result<Option<GraphSnapshot>>> {
-        use crate::workspace_lease::LeaseOutcome;
+    ) -> crate::workspace_lease::LeaseOperationOutcome<Option<GraphSnapshot>, BackgroundSnapshotError>
+    {
+        use crate::workspace_lease::{LeaseOperationError, LeaseOperationOutcome};
 
         if let Some(snapshot) = self.snapshot() {
-            return LeaseOutcome::Applied(Ok(Some(snapshot)));
+            return LeaseOperationOutcome::Applied(Some(snapshot));
         }
         let (generation, fingerprint, force_stale, workspace_roots) = {
             let inner = lock_recover(&self.inner);
             let Some(published) = inner.published.as_ref() else {
-                return LeaseOutcome::Applied(Ok(None));
+                return LeaseOperationOutcome::Applied(None);
             };
             (
                 published.generation,
@@ -476,12 +491,6 @@ impl GraphState {
                 published.search_roots.clone(),
             )
         };
-        match self.lease.with_ownership_outcome(|| ()) {
-            LeaseOutcome::Applied(()) => {}
-            LeaseOutcome::TransientRefusal => return LeaseOutcome::TransientRefusal,
-            LeaseOutcome::Terminal => return LeaseOutcome::Terminal,
-        }
-
         let opened = (|| -> anyhow::Result<(PooledSnapshotEntry, GraphPathIdentity)> {
             #[cfg(test)]
             if self.background_snapshot_failure.load(std::sync::atomic::Ordering::SeqCst) == 2 {
@@ -502,7 +511,11 @@ impl GraphState {
         })();
         let (entry, identity) = match opened {
             Ok(opened) => opened,
-            Err(error) => return LeaseOutcome::Applied(Err(error)),
+            Err(error) => {
+                return LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                    BackgroundSnapshotError::Operation(error),
+                ))
+            }
         };
 
         #[cfg(test)]
@@ -511,7 +524,11 @@ impl GraphState {
                 hook();
             }
         });
-        match self.lease.with_ownership_outcome(|| {
+        let mut prepared = Some((entry, identity));
+        match self.lease.publish_short(&mut prepared, |prepared| {
+            let (_, identity) = prepared
+                .as_ref()
+                .expect("background snapshot publication keeps its prepared value until commit");
             #[cfg(test)]
             if self.background_snapshot_failure.load(std::sync::atomic::Ordering::SeqCst) == 1 {
                 return Err(SnapshotInstallError::Changed);
@@ -520,7 +537,7 @@ impl GraphState {
                 SnapshotInstallError::Operation("graph path unavailable".to_owned())
             })?;
             match GraphPathIdentity::read(&path) {
-                Ok(current) if current == identity => {}
+                Ok(current) if current == *identity => {}
                 Ok(_) => return Err(SnapshotInstallError::Changed),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     return Err(SnapshotInstallError::Changed)
@@ -536,9 +553,10 @@ impl GraphState {
             }
             Ok(())
         }) {
-            LeaseOutcome::Applied(Ok(())) => {
+            LeaseOperationOutcome::Applied(()) => {
+                let (entry, _) = prepared.take().expect("successful publication retains entry");
                 let unread_files = entry.db.unread_files();
-                LeaseOutcome::Applied(Ok(Some(GraphSnapshot {
+                LeaseOperationOutcome::Applied(Some(GraphSnapshot {
                     graph: PooledGraphDb {
                         entry: Some(entry),
                         pool: Arc::clone(&self.snapshot_pool),
@@ -548,32 +566,35 @@ impl GraphState {
                     force_stale,
                     unread_files,
                     workspace_roots,
-                })))
+                }))
             }
-            LeaseOutcome::Applied(Err(SnapshotInstallError::Changed)) => LeaseOutcome::Applied(
-                Err(anyhow::anyhow!("graph changed before background snapshot admission")),
-            ),
-            LeaseOutcome::Applied(Err(SnapshotInstallError::Operation(message))) => {
-                LeaseOutcome::Applied(Err(anyhow::anyhow!(message)))
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                SnapshotInstallError::Changed,
+            )) => LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                BackgroundSnapshotError::Changed,
+            )),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                SnapshotInstallError::Operation(message),
+            )) => LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                BackgroundSnapshotError::Operation(anyhow::anyhow!(message)),
+            )),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error)) => {
+                LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error))
             }
-            LeaseOutcome::TransientRefusal => LeaseOutcome::TransientRefusal,
-            LeaseOutcome::Terminal => LeaseOutcome::Terminal,
+            LeaseOperationOutcome::TransientRefusal => LeaseOperationOutcome::TransientRefusal,
+            LeaseOperationOutcome::Superseded => LeaseOperationOutcome::Superseded,
+            LeaseOperationOutcome::Released => LeaseOperationOutcome::Released,
         }
     }
 
-    /// Report the freshness of `snapshot` relative to disk, and on drift kick an
-    /// async reload (at most one in flight). `stale`/`revision` are relative to the
-    /// snapshot that served the response; the reload decision is relative to the
-    /// latest published snapshot. Walks the filesystem, so call from a blocking
-    /// context.
+    /// Test-only legacy freshness path. Production request handlers use
+    /// `cached_freshness` and never walk disk or start a reload.
+    #[cfg(test)]
     pub(crate) fn freshness(&self, snapshot: &GraphSnapshot) -> Freshness {
         let disk = self.current_disk_fp();
         let stale = snapshot.force_stale
             || snapshot.unread_files > 0
             || disk.map(|(fp, _)| fp != snapshot.fingerprint).unwrap_or(false);
-        // Read before the lock: the lease may go to disk, and the inner mutex serializes every
-        // graph query. Drift is still reported (the response says `stale`), but only the daemon
-        // that owns the workspace's derived caches acts on it — see [`crate::workspace_lease`].
         let may_build = self.may_build();
 
         let mut inner = lock_recover(&self.inner);
@@ -936,10 +957,14 @@ mod tests {
             GraphStatus::Ready { files: 0 },
             None,
         );
-        assert_eq!(
+        assert!(matches!(
             outcome,
-            crate::workspace_lease::LeaseOutcome::Applied(Err(SnapshotInstallError::Changed))
-        );
+            crate::workspace_lease::LeaseOperationOutcome::OperationError(
+                crate::workspace_lease::LeaseOperationError::Operation(
+                    SnapshotInstallError::Changed
+                )
+            )
+        ));
     }
 
     #[test]
@@ -1094,8 +1119,8 @@ mod tests {
     }
 
     #[test]
-    fn blocking_snapshot_classifies_preflight_identity_and_open_failures() {
-        use crate::workspace_lease::LeaseOutcome;
+    fn background_snapshot_preserves_all_typed_outcomes() {
+        use crate::workspace_lease::{LeaseOperationError, LeaseOperationOutcome};
 
         let ready_graph = || {
             let dir = tempfile::tempdir().unwrap();
@@ -1119,13 +1144,13 @@ mod tests {
         let (_dir, graph, lease) = ready_graph();
         let held_lock = lease.hold_file_lock_for_test();
         let started = Instant::now();
-        assert!(matches!(graph.snapshot_blocking(), LeaseOutcome::Applied(Ok(Some(_)))));
+        assert!(matches!(graph.snapshot_blocking(), LeaseOperationOutcome::Applied(Some(_))));
         assert!(started.elapsed() < Duration::from_millis(100), "pool checkout skips preflight");
         drop(held_lock);
 
         let _occupied = occupy(&graph);
         let held_lock = lease.hold_file_lock_for_test();
-        assert!(matches!(graph.snapshot_blocking(), LeaseOutcome::TransientRefusal));
+        assert!(matches!(graph.snapshot_blocking(), LeaseOperationOutcome::TransientRefusal));
         drop(held_lock);
 
         let (_dir, graph, _lease) = ready_graph();
@@ -1134,14 +1159,36 @@ mod tests {
         set_snapshot_install_hook(Box::new(move || {
             lock_recover(&changed.inner).published.as_mut().unwrap().generation += 1;
         }));
-        assert!(matches!(graph.snapshot_blocking(), LeaseOutcome::Applied(Err(_))));
+        assert!(matches!(
+            graph.snapshot_blocking(),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(_))
+        ));
 
         let (_dir, graph, _lease) = ready_graph();
         let _occupied = occupy(&graph);
         graph.set_background_snapshot_failure_for_test(Some(BackgroundSnapshotFailure::Open));
         let result = graph.snapshot_blocking();
         graph.set_background_snapshot_failure_for_test(None);
-        assert!(matches!(result, LeaseOutcome::Applied(Err(_))));
+        assert!(matches!(
+            result,
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(_))
+        ));
+
+        let missing = GraphState::for_workspace(tempfile::tempdir().unwrap().path().to_path_buf());
+        assert!(matches!(missing.snapshot_blocking(), LeaseOperationOutcome::Applied(None)));
+
+        let (_dir, graph, lease) = ready_graph();
+        let _occupied = occupy(&graph);
+        lease.release();
+        assert!(matches!(graph.snapshot_blocking(), LeaseOperationOutcome::Released));
+
+        let (_dir, graph, old) = ready_graph();
+        let _occupied = occupy(&graph);
+        let cache = graph.cache().unwrap().clone();
+        let newer = crate::workspace_lease::WorkspaceLease::claim_cache(&cache);
+        assert!(matches!(graph.snapshot_blocking(), LeaseOperationOutcome::Superseded));
+        old.release();
+        newer.release();
     }
 
     #[test]

--- a/crates/mcp-server/src/graph/state.rs
+++ b/crates/mcp-server/src/graph/state.rs
@@ -5,17 +5,18 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bsl_search::SearchEngine;
 
 use crate::change_hub::{SinkCursor, WorkspaceChangeHub};
+use crate::state::retry_window::{RetryDecision, RetryWindow};
 
 use super::build::PublishAttemptOutcome;
 use super::snapshot::{FpMapState, ScanCache, SnapshotPool};
 use super::types::{
-    FusedStartup, GraphPublishOutcome, GraphPublishSignal, GraphStatus, GraphStatusReport,
-    NudgeOutcome, SUPERSEDED_GRAPH_ERROR,
+    Freshness, FusedStartup, GraphPublishOutcome, GraphPublishSignal, GraphStatus,
+    GraphStatusReport, NudgeOutcome, SUPERSEDED_GRAPH_ERROR,
 };
 
 /// Minimum time between on-disk drift scans. A scan stats every `.bsl`/`.xml`
@@ -192,9 +193,8 @@ pub(crate) struct GraphState {
     /// builds and publishes nothing — it serves what it already holds and lets the owner
     /// maintain the file. Unmanaged (always owning) for a disabled graph and in tests.
     pub(super) lease: crate::workspace_lease::WorkspaceLease,
-    /// The last load stopped on a transient ownership refusal rather than a build failure.
-    /// Terminal supersession never re-arms; an unobserved lock/stale-record transition may.
-    pub(super) withheld_build: Arc<AtomicBool>,
+    /// Trigger-driven retry obligation created only by a transient publication refusal.
+    pub(super) graph_retry: Arc<Mutex<Option<RetryWindow>>>,
 }
 
 impl GraphState {
@@ -247,7 +247,7 @@ impl GraphState {
             #[cfg(test)]
             publish_passes: Arc::new(AtomicUsize::new(0)),
             lease: crate::workspace_lease::WorkspaceLease::unmanaged(),
-            withheld_build: Arc::new(AtomicBool::new(false)),
+            graph_retry: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -261,6 +261,7 @@ impl GraphState {
     /// Whether this daemon may write the shared graph database. A superseded one keeps
     /// serving its published snapshot but schedules no builds: the owner maintains the file,
     /// and two processes rebuilding it only race renames and flicker generations.
+    #[cfg(test)]
     pub(super) fn may_build(&self) -> bool {
         self.lease.owns_caches()
     }
@@ -625,15 +626,31 @@ impl GraphState {
         lock_recover(&self.inner).status.clone()
     }
 
-    /// Lifecycle snapshot for the `status` action. For a ready graph it also reports the
-    /// served revision and on-disk freshness (and, like every freshness check, kicks an async
-    /// reload on drift) — so this walks the filesystem and must be called from a blocking
-    /// context. A `Ready` status whose snapshot momentarily cannot be opened is reported as
-    /// `loading` (a reload is renaming the file into place), never as a torn read. A
-    /// superseded graph reports ready only while one of its own descriptors is idle in the
-    /// pool; it never reopens the shared path.
+    /// Request-safe freshness from the publication paired with this pre-opened snapshot.
+    pub(crate) fn cached_freshness(&self, snapshot: &super::GraphSnapshot) -> Freshness {
+        let (stale, reload, topology) = lock_recover(&self.inner)
+            .published
+            .as_ref()
+            .filter(|published| published.generation == snapshot.generation)
+            .map(|published| {
+                (
+                    published.stale || published.force_stale,
+                    published.reload.label(),
+                    published.fingerprint.topology,
+                )
+            })
+            .unwrap_or((snapshot.force_stale, "none", snapshot.fingerprint.topology));
+        Freshness {
+            revision: snapshot.generation,
+            stale: stale || snapshot.unread_files() > 0,
+            reload,
+            topology,
+        }
+    }
+
+    /// Cached lifecycle snapshot for the `status` action. It uses only process-local state and
+    /// the pre-opened descriptor pool; drift detection belongs to background graph owners.
     pub(crate) fn status_report(&self) -> GraphStatusReport {
-        let _ = self.may_build();
         let superseded = self.lease.is_superseded();
         let report = |state: &'static str, superseded: Option<bool>| GraphStatusReport {
             state,
@@ -646,10 +663,15 @@ impl GraphState {
             superseded,
         };
 
+        let status = {
+            let inner = lock_recover(&self.inner);
+            inner.status.clone()
+        };
+
         if superseded {
-            if let GraphStatus::Ready { files } = self.status() {
+            if let GraphStatus::Ready { files } = status {
                 if let Some(snapshot) = self.snapshot() {
-                    let freshness = self.freshness(&snapshot);
+                    let freshness = self.cached_freshness(&snapshot);
                     return GraphStatusReport {
                         files: Some(files),
                         unread_files: Some(snapshot.unread_files()),
@@ -666,7 +688,7 @@ impl GraphState {
             };
         }
 
-        match self.status() {
+        match status {
             GraphStatus::Disabled => report("disabled", None),
             GraphStatus::Idle | GraphStatus::Loading => report("loading", None),
             GraphStatus::Failed(msg) => {
@@ -674,7 +696,7 @@ impl GraphState {
             }
             GraphStatus::Ready { files } => match self.snapshot() {
                 Some(snapshot) => {
-                    let freshness = self.freshness(&snapshot);
+                    let freshness = self.cached_freshness(&snapshot);
                     GraphStatusReport {
                         files: Some(files),
                         unread_files: Some(snapshot.unread_files()),
@@ -692,19 +714,21 @@ impl GraphState {
     /// Trigger the background load if this is the first call. Transitions
     /// `Idle → Loading` and spawns exactly one loader thread; later calls return
     /// immediately. No-op for disabled / already-loading / ready / failed / terminally
-    /// superseded graphs. A transient fence refusal may re-arm through [`Self::withheld_build`].
+    /// superseded graphs. A transient fence refusal may re-arm through `graph_retry`.
     pub(crate) fn ensure_loading(&self) {
         if self.workspace_root.is_none() || self.superseded_latched() {
             return;
         }
+        let retry_allowed = lock_recover(&self.graph_retry).as_mut().is_some_and(|retry| {
+            matches!(retry.refused(Instant::now(), Duration::ZERO), RetryDecision::RetryAfter(_))
+        });
         {
             let mut inner = lock_recover(&self.inner);
-            let retry_withheld = self.withheld_build.load(Ordering::SeqCst)
-                && matches!(inner.status, GraphStatus::Failed(_));
-            if inner.status != GraphStatus::Idle && !retry_withheld {
+            if inner.status != GraphStatus::Idle
+                && !(retry_allowed && matches!(inner.status, GraphStatus::Failed(_)))
+            {
                 return;
             }
-            self.withheld_build.store(false, Ordering::SeqCst);
             inner.status = GraphStatus::Loading;
         }
 
@@ -758,7 +782,7 @@ impl GraphState {
             GraphStatus::Ready { files },
             None,
         );
-        assert!(matches!(outcome, crate::workspace_lease::LeaseOutcome::Applied(Ok(()))));
+        assert!(matches!(outcome, crate::workspace_lease::LeaseOperationOutcome::Applied(())));
     }
 
     /// Abandon a claimed external build that did not produce a usable database, so the
@@ -798,6 +822,11 @@ impl GraphState {
     fn nudge_after_recording(&self, force_project: bool) -> NudgeOutcome {
         if self.is_superseded() {
             return NudgeOutcome::NoOp;
+        }
+        if matches!(self.status(), GraphStatus::Failed(_)) {
+            if let Some(retry) = lock_recover(&self.graph_retry).as_mut() {
+                retry.observe_external_work(true);
+            }
         }
         match self.status() {
             GraphStatus::Idle => {
@@ -1193,7 +1222,7 @@ mod tests {
         assert!(matches!(
             graph.try_publish_cached(root, 0),
             PublishAttemptOutcome::Refused(super::super::build::LoadFailure {
-                reason: super::super::build::LoadFailureReason::Terminal,
+                reason: super::super::build::LoadFailureReason::Superseded,
                 ..
             })
         ));
@@ -1260,8 +1289,9 @@ mod tests {
             *newer_in_hook.lock().unwrap() =
                 Some(crate::workspace_lease::WorkspaceLease::claim(&root_in_hook));
             assert!(matches!(
-                refusal_lease_in_hook.with_ownership_outcome(|| ()),
-                crate::workspace_lease::LeaseOutcome::Terminal
+                refusal_lease_in_hook
+                    .publish_short(&mut (), |_| { Ok::<_, std::convert::Infallible>(()) }),
+                crate::workspace_lease::LeaseOperationOutcome::Superseded
             ));
             GraphPublishOutcome { topology_handled: false, roots_handled: true }
         });

--- a/crates/mcp-server/src/graph/state.rs
+++ b/crates/mcp-server/src/graph/state.rs
@@ -856,8 +856,8 @@ impl GraphState {
                     NudgeOutcome::NoOp
                 }
             }
-            // Only a transient fence refusal is retryable here. Terminal supersession returned
-            // above and never resumes after the foreign owner exits.
+            // Fresh external work may start a new epoch after a transient refusal or operation
+            // failure. Terminal supersession returned above never resumes.
             GraphStatus::Failed(_) => {
                 self.ensure_loading();
                 match self.status() {

--- a/crates/mcp-server/src/inventory.rs
+++ b/crates/mcp-server/src/inventory.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-const BASE: &str = "f8bf4da5831840070aa19477be68e74d78014fa6";
+const BASE: &str = "edc78e22f3efbfe51ffd8e6dfd05b457976195ca";
 
 fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in std::fs::read_dir(dir).expect("source directory is readable") {

--- a/crates/mcp-server/src/inventory.rs
+++ b/crates/mcp-server/src/inventory.rs
@@ -1,0 +1,117 @@
+use std::path::{Path, PathBuf};
+
+const BASE: &str = "f8bf4da5831840070aa19477be68e74d78014fa6";
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("source directory is readable") {
+        let path = entry.expect("source entry is readable").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|extension| extension == "rs")
+            && path.file_name().is_none_or(|name| name != "inventory.rs")
+        {
+            out.push(path);
+        }
+    }
+}
+
+fn production_sources() -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    rust_sources(&Path::new(env!("CARGO_MANIFEST_DIR")).join("src"), &mut sources);
+    sources
+}
+
+fn production_prefix(source: &str) -> &str {
+    source.split("\n#[cfg(test)]\nmod ").next().unwrap_or(source)
+}
+
+#[test]
+fn no_generic_or_unclassified_production_lease_callers() {
+    let forbidden = ["with_ownership_outcome", "with_ownership_checkpointed", "LeaseOutcome"];
+    for path in production_sources() {
+        let source = std::fs::read_to_string(&path).expect("Rust source is readable");
+        for token in forbidden {
+            assert!(!source.contains(token), "{} still contains {token}", path.display());
+        }
+    }
+}
+
+#[test]
+fn prepared_work_stays_outside_lease_fences() {
+    let allowed = [
+        "graph/build.rs",
+        "graph/snapshot.rs",
+        "graph/state.rs",
+        "state/bootstrap.rs",
+        "state/embed.rs",
+        "state/mod.rs",
+        "workspace_lease.rs",
+    ];
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    for path in production_sources() {
+        let source = std::fs::read_to_string(&path).expect("Rust source is readable");
+        if source.contains(".publish_short(") || source.contains(".publish_checkpointed(") {
+            let relative = path.strip_prefix(&root).unwrap().to_string_lossy();
+            assert!(allowed.contains(&relative.as_ref()), "unclassified fence caller: {relative}");
+        }
+    }
+}
+
+#[test]
+fn no_new_runtime_or_compatibility_surface() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root is readable");
+    let cargo_lock = std::process::Command::new("git")
+        .args(["diff", "--exit-code", BASE, "--", "Cargo.lock"])
+        .current_dir(&root)
+        .status()
+        .expect("git is available");
+    assert!(cargo_lock.success(), "Cargo.lock changed from the locked base");
+
+    let diff = std::process::Command::new("git")
+        .args([
+            "diff",
+            "--unified=0",
+            BASE,
+            "--",
+            "crates/bsl-search/src",
+            "crates/mcp-server/src",
+            ":(exclude)crates/mcp-server/src/inventory.rs",
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("git is available");
+    assert!(diff.status.success(), "git diff failed");
+    let added = String::from_utf8(diff.stdout)
+        .expect("git diff is UTF-8")
+        .lines()
+        .filter(|line| line.starts_with('+') && !line.starts_with("+++"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for forbidden in
+        ["SCHEMA_VERSION_CURRENT", "ALTER TABLE", "CREATE TABLE", "Serialize", "Deserialize"]
+    {
+        assert!(!added.contains(forbidden), "new compatibility/runtime surface: {forbidden}");
+    }
+
+    for path in production_sources() {
+        let relative = path.strip_prefix(&root).expect("source is under repository root");
+        let current = std::fs::read_to_string(&path).expect("Rust source is readable");
+        let previous = std::process::Command::new("git")
+            .args(["show", &format!("{BASE}:{}", relative.display())])
+            .current_dir(&root)
+            .output()
+            .expect("git is available");
+        let previous = String::from_utf8(previous.stdout).expect("base source is UTF-8");
+        for token in ["tokio::spawn", "std::thread::spawn", "thread::Builder::new"] {
+            assert!(
+                production_prefix(&current).matches(token).count()
+                    <= production_prefix(&previous).matches(token).count(),
+                "new production runtime surface in {}: {token}",
+                relative.display()
+            );
+        }
+    }
+}

--- a/crates/mcp-server/src/inventory.rs
+++ b/crates/mcp-server/src/inventory.rs
@@ -37,22 +37,52 @@ fn no_generic_or_unclassified_production_lease_callers() {
 }
 
 #[test]
-fn prepared_work_stays_outside_lease_fences() {
-    let allowed = [
-        "graph/build.rs",
-        "graph/snapshot.rs",
-        "graph/state.rs",
-        "state/bootstrap.rs",
-        "state/embed.rs",
-        "state/mod.rs",
-        "workspace_lease.rs",
+fn fence_callers_are_exactly_classified() {
+    let expected = [
+        ("graph/build.rs", 2),
+        ("graph/snapshot.rs", 2),
+        ("state/bootstrap.rs", 2),
+        ("state/embed.rs", 4),
+        ("state/mod.rs", 2),
+        ("workspace_lease.rs", 1),
     ];
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     for path in production_sources() {
         let source = std::fs::read_to_string(&path).expect("Rust source is readable");
-        if source.contains(".publish_short(") || source.contains(".publish_checkpointed(") {
-            let relative = path.strip_prefix(&root).unwrap().to_string_lossy();
-            assert!(allowed.contains(&relative.as_ref()), "unclassified fence caller: {relative}");
+        let source = production_prefix(&source);
+        let actual = source.matches(".publish_short(").count()
+            + source.matches(".publish_checkpointed(").count();
+        let relative = path.strip_prefix(&root).unwrap().to_string_lossy();
+        let classified = expected
+            .iter()
+            .find_map(|(path, count)| (*path == relative).then_some(*count))
+            .unwrap_or(0);
+        assert_eq!(actual, classified, "unclassified fence caller count in {relative}");
+    }
+}
+
+#[test]
+fn request_paths_do_not_call_lease_or_mutation_helpers() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let lib = root.join("lib.rs");
+    let tools = root.join("tools");
+    let forbidden = [
+        ".publish_short(",
+        ".publish_checkpointed(",
+        ".owns_caches(",
+        ".owns_caches_now(",
+        "apply_workspace_search(",
+        "apply_workspace_search_checkpointed(",
+        "prefetch_resident_overlay",
+        "snapshot_blocking(",
+    ];
+    for path in
+        production_sources().into_iter().filter(|path| path == &lib || path.starts_with(&tools))
+    {
+        let source = std::fs::read_to_string(&path).expect("Rust source is readable");
+        let source = production_prefix(&source);
+        for token in forbidden {
+            assert!(!source.contains(token), "{} contains request-time {token}", path.display());
         }
     }
 }
@@ -105,7 +135,12 @@ fn no_new_runtime_or_compatibility_surface() {
             .output()
             .expect("git is available");
         let previous = String::from_utf8(previous.stdout).expect("base source is UTF-8");
-        for token in ["tokio::spawn", "std::thread::spawn", "thread::Builder::new"] {
+        for token in [
+            "tokio::spawn",
+            "tokio::task::spawn_blocking",
+            "std::thread::spawn",
+            "thread::Builder::new",
+        ] {
             assert!(
                 production_prefix(&current).matches(token).count()
                     <= production_prefix(&previous).matches(token).count(),

--- a/crates/mcp-server/src/inventory.rs
+++ b/crates/mcp-server/src/inventory.rs
@@ -1,7 +1,5 @@
 use std::path::{Path, PathBuf};
 
-const BASE: &str = "edc78e22f3efbfe51ffd8e6dfd05b457976195ca";
-
 fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in std::fs::read_dir(dir).expect("source directory is readable") {
         let path = entry.expect("source entry is readable").path();
@@ -22,7 +20,21 @@ fn production_sources() -> Vec<PathBuf> {
 }
 
 fn production_prefix(source: &str) -> &str {
-    source.split("\n#[cfg(test)]\nmod ").next().unwrap_or(source)
+    source
+        .split("\n#[cfg(test)]\nmod ")
+        .next()
+        .unwrap_or(source)
+        .split("\r\n#[cfg(test)]\r\nmod ")
+        .next()
+        .unwrap_or(source)
+}
+
+#[test]
+fn production_prefix_handles_checkout_line_endings() {
+    for newline in ["\n", "\r\n"] {
+        let source = format!("fn production() {{}}{newline}#[cfg(test)]{newline}mod tests {{}}");
+        assert_eq!(production_prefix(&source), "fn production() {}");
+    }
 }
 
 #[test]
@@ -52,12 +64,12 @@ fn fence_callers_are_exactly_classified() {
         let source = production_prefix(&source);
         let actual = source.matches(".publish_short(").count()
             + source.matches(".publish_checkpointed(").count();
-        let relative = path.strip_prefix(&root).unwrap().to_string_lossy();
+        let relative = path.strip_prefix(&root).unwrap();
         let classified = expected
             .iter()
-            .find_map(|(path, count)| (*path == relative).then_some(*count))
+            .find_map(|(path, count)| (Path::new(path) == relative).then_some(*count))
             .unwrap_or(0);
-        assert_eq!(actual, classified, "unclassified fence caller count in {relative}");
+        assert_eq!(actual, classified, "unclassified fence caller count in {}", relative.display());
     }
 }
 
@@ -83,70 +95,6 @@ fn request_paths_do_not_call_lease_or_mutation_helpers() {
         let source = production_prefix(&source);
         for token in forbidden {
             assert!(!source.contains(token), "{} contains request-time {token}", path.display());
-        }
-    }
-}
-
-#[test]
-fn no_new_runtime_or_compatibility_surface() {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .expect("repository root is readable");
-    let cargo_lock = std::process::Command::new("git")
-        .args(["diff", "--exit-code", BASE, "--", "Cargo.lock"])
-        .current_dir(&root)
-        .status()
-        .expect("git is available");
-    assert!(cargo_lock.success(), "Cargo.lock changed from the locked base");
-
-    let diff = std::process::Command::new("git")
-        .args([
-            "diff",
-            "--unified=0",
-            BASE,
-            "--",
-            "crates/bsl-search/src",
-            "crates/mcp-server/src",
-            ":(exclude)crates/mcp-server/src/inventory.rs",
-        ])
-        .current_dir(&root)
-        .output()
-        .expect("git is available");
-    assert!(diff.status.success(), "git diff failed");
-    let added = String::from_utf8(diff.stdout)
-        .expect("git diff is UTF-8")
-        .lines()
-        .filter(|line| line.starts_with('+') && !line.starts_with("+++"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    for forbidden in
-        ["SCHEMA_VERSION_CURRENT", "ALTER TABLE", "CREATE TABLE", "Serialize", "Deserialize"]
-    {
-        assert!(!added.contains(forbidden), "new compatibility/runtime surface: {forbidden}");
-    }
-
-    for path in production_sources() {
-        let relative = path.strip_prefix(&root).expect("source is under repository root");
-        let current = std::fs::read_to_string(&path).expect("Rust source is readable");
-        let previous = std::process::Command::new("git")
-            .args(["show", &format!("{BASE}:{}", relative.display())])
-            .current_dir(&root)
-            .output()
-            .expect("git is available");
-        let previous = String::from_utf8(previous.stdout).expect("base source is UTF-8");
-        for token in [
-            "tokio::spawn",
-            "tokio::task::spawn_blocking",
-            "std::thread::spawn",
-            "thread::Builder::new",
-        ] {
-            assert!(
-                production_prefix(&current).matches(token).count()
-                    <= production_prefix(&previous).matches(token).count(),
-                "new production runtime surface in {}: {token}",
-                relative.display()
-            );
         }
     }
 }

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -10,6 +10,8 @@ mod graph;
 mod graph_db;
 mod graph_query;
 mod http;
+#[cfg(test)]
+mod inventory;
 pub mod project;
 mod state;
 mod tasks;
@@ -1015,7 +1017,7 @@ impl McpServer {
             diag.ensure_loading();
             return Ok(tools::resident::status(
                 &diag.status_report(),
-                self.state.owns_caches(),
+                self.state.owns_caches_cached(),
                 self.state.standalone_notice().as_deref(),
             )
             .into());
@@ -1244,12 +1246,11 @@ impl McpServer {
                 let configured_baseline = baseline.configured;
                 let external_baseline = baseline.external;
                 let index_progress = self.state.index_progress().clone();
+                self.state.request_overlay_refresh();
                 let retry_progress = index_progress.clone();
-                let workspace_lease = self.state.workspace_lease().clone();
                 let outcome = tools::search::search_call(ct, move |cancel| {
-                    tools::search::hybrid_code_fenced(
+                    tools::search::hybrid_code_cancellable(
                         &engine,
-                        &workspace_lease,
                         cancel,
                         &semantic_runtime,
                         workspace_search_mode,
@@ -1689,9 +1690,7 @@ impl McpServer {
         // it and poll progress instead of reading a flat `loading` envelope from a data action.
         if p.action == "status" {
             graph.ensure_loading();
-            let report = tokio::task::spawn_blocking(move || graph.status_report())
-                .await
-                .map_err(|e| McpError::internal_error(format!("Task error: {e}"), None))?;
+            let report = graph.status_report();
             return Ok(tools::graph::status(&report));
         }
 
@@ -1797,10 +1796,9 @@ impl McpServer {
                     return Err(contract::unknown_action(McpProfile::Workspace, "graph", other))
                 }
             };
-            // Stamp freshness relative to the snapshot that served this answer: the
-            // scan may detect drift and kick a background reload, but `revision`
-            // and `stale` describe the data actually returned above.
-            let freshness = graph.freshness(&snapshot);
+            // Request reads report the publication already paired with this descriptor;
+            // background owners detect drift and schedule reloads.
+            let freshness = graph.cached_freshness(&snapshot);
             // Modules the artefact could not read are missing nodes and edges: that is
             // incompleteness of the answer, not merely drift.
             let completeness = completeness.when(
@@ -2211,7 +2209,7 @@ impl McpServer {
                 diag.ensure_loading();
                 Ok(tools::resident::status(
                     &diag.status_report(),
-                    self.state.owns_caches(),
+                    self.state.owns_caches_cached(),
                     self.state.standalone_notice().as_deref(),
                 )
                 .into())
@@ -3001,6 +2999,104 @@ mod surface_guards {
 }
 
 #[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn all_status_requests_are_cached_under_held_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        crate::graph::test_support::sample_workspace(root);
+        std::fs::write(root.join("Configuration.xml"), "<Configuration/>").unwrap();
+        let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
+        let state = SharedState::workspace_with_cache(root.to_path_buf(), cache).unwrap();
+        let lease = state.workspace_lease().clone();
+        let server = McpServer::new(McpProfile::Workspace, state);
+        let held_lease = lease.hold_file_lock_for_test();
+        let token = || tokio_util::sync::CancellationToken::new();
+
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            server.metadata(
+                Parameters(MetadataParams {
+                    action: "status".to_owned(),
+                    filter: None,
+                    meta_type: None,
+                    name_mask: None,
+                    max_items: None,
+                    object_type: None,
+                    object_name: None,
+                    form_name: None,
+                    max_output_tokens: None,
+                    connection: None,
+                    mode: None,
+                }),
+                token(),
+                tasks::TaskCapable(false),
+            ),
+        )
+        .await
+        .expect("metadata status must not wait for the lease lock")
+        .expect("metadata status response");
+
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            server.diagnostics(
+                Parameters(DiagnosticsParams {
+                    action: "status".to_owned(),
+                    path: None,
+                    root_id: None,
+                    codes: Vec::new(),
+                    locale: None,
+                    min_severity: None,
+                    range_start: None,
+                    range_end: None,
+                    detail: None,
+                    max_findings: None,
+                    max_files: None,
+                    max_output_tokens: None,
+                }),
+                token(),
+                tasks::TaskCapable(false),
+            ),
+        )
+        .await
+        .expect("diagnostics status must not wait for the lease lock")
+        .expect("diagnostics status response");
+
+        tokio::time::timeout(
+            Duration::from_millis(500),
+            server.graph(
+                Parameters(GraphParams {
+                    action: "status".to_owned(),
+                    id: None,
+                    query: None,
+                    ids: Vec::new(),
+                    max_output_tokens: None,
+                    detail: None,
+                    dir: None,
+                    depth: None,
+                    max_nodes: None,
+                    provenance: Vec::new(),
+                    edge_kinds: Vec::new(),
+                    top: None,
+                    call_sites: None,
+                    max_call_sites: None,
+                }),
+                token(),
+            ),
+        )
+        .await
+        .expect("graph status must not wait for the lease lock")
+        .expect("graph status response");
+
+        drop(held_lease);
+        server.shutdown();
+    }
+}
+
+#[cfg(test)]
 mod graph_supersession_contract {
     use super::*;
     use std::time::Duration;
@@ -3045,10 +3141,31 @@ mod graph_supersession_contract {
         })
     }
 
+    fn references_params(symbol: &str) -> Parameters<ReferencesParams> {
+        Parameters(ReferencesParams {
+            symbol: Some(symbol.to_owned()),
+            anchor_root_id: None,
+            root_id: None,
+            path: None,
+            line: None,
+            column: None,
+            line_content: None,
+            area_root_id: None,
+            area_path_prefix: None,
+            kinds: Vec::new(),
+            include_declaration: None,
+            limit: None,
+            max_files: None,
+            include_preview: None,
+            max_output_tokens: None,
+        })
+    }
+
     enum BusyGraphHandler {
         Graph,
         ResolveNames,
         SymbolInfo,
+        References,
     }
 
     async fn assert_busy_graph_handler_returns_immediately(handler: BusyGraphHandler) {
@@ -3105,6 +3222,23 @@ mod graph_supersession_contract {
                     _ => panic!("a caller that declared no task extension is answered inline"),
                 }
             }
+            BusyGraphHandler::References => {
+                let response = tokio::time::timeout(
+                    Duration::from_millis(500),
+                    server.references(
+                        references_params("Сервер.Считать"),
+                        token(),
+                        tasks::TaskCapable(false),
+                    ),
+                )
+                .await
+                .expect("references must not wait for the lease lock")
+                .expect("resident references survive unavailable graph enrichment");
+                match response {
+                    rmcp::model::CallToolResponse::Complete(result) => result,
+                    _ => panic!("a caller that declared no task extension is answered inline"),
+                }
+            }
         };
         assert!(answer.structured_content.is_some());
 
@@ -3126,6 +3260,11 @@ mod graph_supersession_contract {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn symbol_info_misses_immediately_when_preopened_handles_are_busy() {
         assert_busy_graph_handler_returns_immediately(BusyGraphHandler::SymbolInfo).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn references_misses_immediately_when_preopened_handles_are_busy() {
+        assert_busy_graph_handler_returns_immediately(BusyGraphHandler::References).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -3010,10 +3010,13 @@ mod tests {
         crate::graph::test_support::sample_workspace(root);
         std::fs::write(root.join("Configuration.xml"), "<Configuration/>").unwrap();
         let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
+        let lease_path = cache.lease_path();
         let state = SharedState::workspace_with_cache(root.to_path_buf(), cache).unwrap();
         let lease = state.workspace_lease().clone();
         let server = McpServer::new(McpProfile::Workspace, state);
         let held_lease = lease.hold_file_lock_for_test();
+        std::fs::remove_file(lease_path).unwrap();
+        lease.invalidate_verdict_for_test();
         let token = || tokio_util::sync::CancellationToken::new();
 
         tokio::time::timeout(

--- a/crates/mcp-server/src/state/bootstrap.rs
+++ b/crates/mcp-server/src/state/bootstrap.rs
@@ -291,6 +291,12 @@ impl SharedState {
     ) -> Result<Self, WorkspaceInitError> {
         let project = crate::project::at(&source_dir)?;
         let source_root = project.configuration_path().map(Path::to_path_buf);
+        let notices: Vec<String> =
+            [project.standalone_extension_notice(), project.standalone_external_notice()]
+                .into_iter()
+                .flatten()
+                .collect();
+        let standalone_notice = (!notices.is_empty()).then(|| notices.join("\n"));
 
         // One value, used by everything that reads the tree: the watch, the walk that
         // feeds the graph and the search index, and the roots the engine registers. Two
@@ -483,6 +489,7 @@ impl SharedState {
         Ok(Self {
             workspace_root: Some(source_dir),
             source_root,
+            standalone_notice,
             onec_client: None,
             onec_connections: Default::default(),
             debug_session: Arc::new(Mutex::new(None)),
@@ -661,7 +668,10 @@ impl SharedState {
                         Ok(bsl_search::FenceOutcome::TransientRefusal) => {
                             unreachable!("startup_apply retries transient refusals")
                         }
-                        Ok(bsl_search::FenceOutcome::Terminal) => Ok(None),
+                        Ok(
+                            bsl_search::FenceOutcome::Superseded
+                            | bsl_search::FenceOutcome::Released,
+                        ) => Ok(None),
                         Err(error) => Err(error),
                     },
                     OverlayInit::RemoteWarmup => Ok(Some(())),
@@ -804,6 +814,7 @@ impl SharedState {
         Self {
             workspace_root: None,
             source_root: None,
+            standalone_notice: None,
             onec_client: None,
             onec_connections: Default::default(),
             debug_session: Arc::new(Mutex::new(None)),
@@ -830,6 +841,7 @@ impl SharedState {
         Self {
             workspace_root: None,
             source_root: None,
+            standalone_notice: None,
             onec_client: None,
             onec_connections: Default::default(),
             debug_session: Arc::new(Mutex::new(None)),
@@ -968,19 +980,11 @@ impl SharedState {
         lease: &crate::workspace_lease::WorkspaceLease,
         mut apply: impl FnMut() -> Result<T, bsl_search::SearchError>,
     ) -> bsl_search::FenceOutcome<Result<T, bsl_search::SearchError>> {
-        loop {
-            match lease.with_ownership_outcome(&mut apply) {
-                crate::workspace_lease::LeaseOutcome::Applied(result) => {
-                    return bsl_search::FenceOutcome::Applied(result)
-                }
-                crate::workspace_lease::LeaseOutcome::TransientRefusal => {
-                    std::thread::sleep(crate::workspace_lease::VERDICT_TTL)
-                }
-                crate::workspace_lease::LeaseOutcome::Terminal => {
-                    return bsl_search::FenceOutcome::Terminal
-                }
-            }
-        }
+        Self::startup_retry(
+            || Self::search_fence_outcome(lease.publish_short(&mut (), |_| apply())),
+            std::time::Instant::now,
+            std::thread::sleep,
+        )
     }
 
     pub(super) fn startup_apply_checkpointed(
@@ -989,17 +993,40 @@ impl SharedState {
             &mut dyn FnMut() -> std::ops::ControlFlow<()>,
         ) -> std::ops::ControlFlow<(), Result<(), bsl_search::SearchError>>,
     ) -> bsl_search::FenceOutcome<Result<(), bsl_search::SearchError>> {
+        Self::startup_retry(
+            || {
+                Self::search_fence_outcome(
+                    lease.publish_checkpointed(|checkpoint| apply(checkpoint)),
+                )
+            },
+            std::time::Instant::now,
+            std::thread::sleep,
+        )
+    }
+
+    fn startup_retry<T>(
+        mut attempt: impl FnMut() -> bsl_search::FenceOutcome<Result<T, bsl_search::SearchError>>,
+        mut now: impl FnMut() -> std::time::Instant,
+        mut sleep: impl FnMut(std::time::Duration),
+    ) -> bsl_search::FenceOutcome<Result<T, bsl_search::SearchError>> {
+        use super::retry_window::{RetryDecision, RetryOwner, RetryWindow};
+
+        let mut retry = RetryWindow::new(RetryOwner::Startup);
         loop {
-            match lease.with_ownership_checkpointed(|checkpoint| apply(checkpoint)) {
-                crate::workspace_lease::LeaseOutcome::Applied(result) => {
-                    return bsl_search::FenceOutcome::Applied(result)
+            match attempt() {
+                bsl_search::FenceOutcome::TransientRefusal => {
+                    match retry.refused(now(), std::time::Duration::from_secs(2)) {
+                        RetryDecision::RetryAfter(delay) => sleep(delay),
+                        RetryDecision::Stop(_) => {
+                            return bsl_search::FenceOutcome::Applied(Err(
+                                bsl_search::SearchError::Index(
+                                    "workspace lease startup retry budget exhausted".to_owned(),
+                                ),
+                            ));
+                        }
+                    }
                 }
-                crate::workspace_lease::LeaseOutcome::TransientRefusal => {
-                    std::thread::sleep(crate::workspace_lease::VERDICT_TTL)
-                }
-                crate::workspace_lease::LeaseOutcome::Terminal => {
-                    return bsl_search::FenceOutcome::Terminal
-                }
+                outcome => return outcome,
             }
         }
     }
@@ -1017,7 +1044,7 @@ impl SharedState {
         match outcome {
             bsl_search::FenceOutcome::Applied(Ok(())) => Ok(value),
             bsl_search::FenceOutcome::Applied(Err(error)) => Err(error),
-            bsl_search::FenceOutcome::Terminal => Ok(None),
+            bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released => Ok(None),
             bsl_search::FenceOutcome::TransientRefusal => {
                 unreachable!("startup_apply retries transient refusals")
             }
@@ -1055,7 +1082,7 @@ impl SharedState {
         match outcome {
             bsl_search::FenceOutcome::Applied(Ok(())) => Ok(value),
             bsl_search::FenceOutcome::Applied(Err(error)) => Err(error),
-            bsl_search::FenceOutcome::Terminal => Ok(None),
+            bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released => Ok(None),
             bsl_search::FenceOutcome::TransientRefusal => {
                 unreachable!("startup apply retries transient refusals")
             }
@@ -1079,7 +1106,7 @@ impl SharedState {
             bsl_search::FenceOutcome::TransientRefusal => {
                 unreachable!("startup_apply retries transient refusals")
             }
-            bsl_search::FenceOutcome::Terminal => None,
+            bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released => None,
         })
     }
 
@@ -1100,7 +1127,7 @@ impl SharedState {
             bsl_search::FenceOutcome::TransientRefusal => {
                 unreachable!("startup_apply retries transient refusals")
             }
-            bsl_search::FenceOutcome::Terminal => None,
+            bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released => None,
         })
     }
 
@@ -1154,7 +1181,14 @@ impl SharedState {
         store: &bsl_search::Store,
         lease: &crate::workspace_lease::WorkspaceLease,
     ) {
-        if let Err(error) = Self::startup_apply_once(lease, || store.clear_baseline_manifest()) {
+        let cleared = Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+            match store.clear_baseline_manifest_checkpointed(checkpoint) {
+                Ok(std::ops::ControlFlow::Continue(())) => std::ops::ControlFlow::Continue(Ok(())),
+                Ok(std::ops::ControlFlow::Break(())) => std::ops::ControlFlow::Break(()),
+                Err(error) => std::ops::ControlFlow::Continue(Err(error)),
+            }
+        });
+        if let Err(error) = cleared {
             tracing::warn!("failed to clear stale workspace baseline manifest: {error}");
         }
     }
@@ -1226,13 +1260,15 @@ impl SharedState {
                 return Ok(None);
             };
             let roots = Self::roots_of(&project, &excluded);
-            let Some(()) = Self::startup_apply_once(lease, || {
-                Self::configure_workspace_engine(
+            let Some(()) = Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+                if let Err(error) = Self::configure_workspace_engine(
                     &mut engine,
                     roots,
                     BaselineHashMode::NormalizedChunks,
-                )?;
-                engine.set_serves_external_baseline(true)
+                ) {
+                    return std::ops::ControlFlow::Continue(Err(error));
+                }
+                engine.set_serves_external_baseline_checkpointed(true, checkpoint)
             })?
             else {
                 return Ok(None);
@@ -1288,8 +1324,18 @@ impl SharedState {
                         {
                             Ok(manifest) => {
                                 let manifest_files = manifest.files.len();
-                                match Self::startup_apply_once(lease, || {
-                                    store.save_baseline_manifest(&manifest)
+                                match Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+                                    match store
+                                        .save_baseline_manifest_checkpointed(&manifest, checkpoint)
+                                    {
+                                        Ok(std::ops::ControlFlow::Continue(())) => {
+                                            std::ops::ControlFlow::Continue(Ok(()))
+                                        }
+                                        Ok(std::ops::ControlFlow::Break(())) => {
+                                            std::ops::ControlFlow::Break(())
+                                        }
+                                        Err(error) => std::ops::ControlFlow::Continue(Err(error)),
+                                    }
                                 }) {
                                     Ok(Some(())) => {}
                                     Ok(None) => return Ok(None),
@@ -1366,9 +1412,13 @@ impl SharedState {
         // a row surviving the local period would suppress a same-stat edit after a switch
         // back to the same snapshot. A failed clear leaves that lie standing, so the boot
         // fails closed, exactly like the Postgres branch does on its own failed clears.
-        let Some(()) = Self::startup_apply_once(lease, || {
-            Self::configure_workspace_engine(&mut engine, roots, BaselineHashMode::RawFileBytes)?;
-            engine.set_serves_external_baseline(false)
+        let Some(()) = Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+            if let Err(error) =
+                Self::configure_workspace_engine(&mut engine, roots, BaselineHashMode::RawFileBytes)
+            {
+                return std::ops::ControlFlow::Continue(Err(error));
+            }
+            engine.set_serves_external_baseline_checkpointed(false, checkpoint)
         })?
         else {
             return Ok(None);
@@ -1455,7 +1505,9 @@ impl SharedState {
                         tracing::info!(indexed, "FTS + graph context written; embedding deferred");
                     }
                 }
-                Ok(bsl_search::FenceOutcome::Terminal) => return Ok(None),
+                Ok(bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released) => {
+                    return Ok(None)
+                }
                 Ok(bsl_search::FenceOutcome::TransientRefusal) => {
                     unreachable!("startup_apply retries transient refusals")
                 }
@@ -1503,7 +1555,9 @@ impl SharedState {
                 Ok(bsl_search::FenceOutcome::Applied(indexed)) => {
                     tracing::info!(indexed, "FTS index built")
                 }
-                Ok(bsl_search::FenceOutcome::Terminal) => return Ok(None),
+                Ok(bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released) => {
+                    return Ok(None)
+                }
                 Ok(bsl_search::FenceOutcome::TransientRefusal) => {
                     unreachable!("startup_apply retries transient refusals")
                 }
@@ -1533,7 +1587,9 @@ impl SharedState {
                     )
                 }
                 Ok(bsl_search::FenceOutcome::Applied(_)) => {}
-                Ok(bsl_search::FenceOutcome::Terminal) => return Ok(None),
+                Ok(bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released) => {
+                    return Ok(None)
+                }
                 Ok(bsl_search::FenceOutcome::TransientRefusal) => {
                     unreachable!("startup_apply retries transient refusals")
                 }
@@ -1840,7 +1896,7 @@ mod tests {
         };
         assert!(matches!(
             SharedState::startup_apply(&old, &mut terminal_apply),
-            bsl_search::FenceOutcome::Terminal
+            bsl_search::FenceOutcome::Superseded
         ));
         assert!(old.is_superseded());
         assert_eq!(terminal_calls.load(Ordering::SeqCst), 0);
@@ -1850,7 +1906,7 @@ mod tests {
         released.release();
         assert!(matches!(
             SharedState::startup_apply(&released, &mut || Ok(())),
-            bsl_search::FenceOutcome::Terminal
+            bsl_search::FenceOutcome::Released
         ));
 
         let error = SharedState::startup_apply(
@@ -1862,6 +1918,29 @@ mod tests {
             bsl_search::FenceOutcome::Applied(Err(bsl_search::SearchError::Index(message)))
                 if message == "expected"
         ));
+    }
+
+    #[test]
+    fn startup_lease_retry_stops_at_600_seconds() {
+        let started = std::time::Instant::now();
+        let clock = std::cell::Cell::new(started);
+        let attempts = std::cell::Cell::new(0_u16);
+        let outcome = SharedState::startup_retry(
+            || {
+                attempts.set(attempts.get() + 1);
+                bsl_search::FenceOutcome::<Result<(), bsl_search::SearchError>>::TransientRefusal
+            },
+            || clock.get(),
+            |delay| clock.set(clock.get().checked_add(delay).unwrap()),
+        );
+
+        assert!(matches!(
+            outcome,
+            bsl_search::FenceOutcome::Applied(Err(bsl_search::SearchError::Index(message)))
+                if message == "workspace lease startup retry budget exhausted"
+        ));
+        assert_eq!(clock.get().duration_since(started), std::time::Duration::from_secs(600));
+        assert_eq!(attempts.get(), 301);
     }
 
     #[test]
@@ -1956,7 +2035,7 @@ mod tests {
                 result
             })
             .unwrap();
-        assert!(matches!(result, bsl_search::FenceOutcome::Terminal));
+        assert!(matches!(result, bsl_search::FenceOutcome::Superseded));
         assert_eq!(
             admitted,
             bsl_search::WORKSPACE_APPLY_BATCH_ROWS,
@@ -1975,7 +2054,7 @@ mod tests {
                     SharedState::startup_apply(&old, apply)
                 })
                 .unwrap(),
-            bsl_search::FenceOutcome::Terminal
+            bsl_search::FenceOutcome::Superseded
         ));
         assert_eq!(
             partial.file_count().unwrap(),
@@ -2005,7 +2084,7 @@ mod tests {
                     SharedState::startup_apply(&old, apply)
                 })
                 .unwrap(),
-            bsl_search::FenceOutcome::Terminal
+            bsl_search::FenceOutcome::Superseded
         ));
         assert!(!prime.workspace_overlay_retry_signals().unwrap().initialized);
         drop(newer);

--- a/crates/mcp-server/src/state/bootstrap.rs
+++ b/crates/mcp-server/src/state/bootstrap.rs
@@ -1051,24 +1051,16 @@ impl SharedState {
         }
     }
 
-    fn startup_apply_checkpointed_once<T>(
+    fn startup_apply_checkpointed_value<T>(
         lease: &crate::workspace_lease::WorkspaceLease,
-        operation: impl FnOnce(
+        mut operation: impl FnMut(
             &mut dyn FnMut() -> std::ops::ControlFlow<()>,
-        ) -> std::ops::ControlFlow<(), Result<T, bsl_search::SearchError>>,
+        )
+            -> std::ops::ControlFlow<(), Result<T, bsl_search::SearchError>>,
     ) -> Result<Option<T>, bsl_search::SearchError> {
-        let mut operation = Some(operation);
         let mut value = None;
-        let outcome = Self::startup_apply_checkpointed(lease, |checkpoint| {
-            let operation = match operation.take() {
-                Some(operation) => operation,
-                None => {
-                    return std::ops::ControlFlow::Continue(Err(bsl_search::SearchError::Index(
-                        "checkpointed startup operation invoked more than once".to_owned(),
-                    )));
-                }
-            };
-            match operation(checkpoint) {
+        let outcome =
+            Self::startup_apply_checkpointed(lease, |checkpoint| match operation(checkpoint) {
                 std::ops::ControlFlow::Break(()) => std::ops::ControlFlow::Break(()),
                 std::ops::ControlFlow::Continue(Err(error)) => {
                     std::ops::ControlFlow::Continue(Err(error))
@@ -1077,8 +1069,7 @@ impl SharedState {
                     value = Some(result);
                     std::ops::ControlFlow::Continue(Ok(()))
                 }
-            }
-        });
+            });
         match outcome {
             bsl_search::FenceOutcome::Applied(Ok(())) => Ok(value),
             bsl_search::FenceOutcome::Applied(Err(error)) => Err(error),
@@ -1181,7 +1172,7 @@ impl SharedState {
         store: &bsl_search::Store,
         lease: &crate::workspace_lease::WorkspaceLease,
     ) {
-        let cleared = Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+        let cleared = Self::startup_apply_checkpointed_value(lease, |checkpoint| {
             match store.clear_baseline_manifest_checkpointed(checkpoint) {
                 Ok(std::ops::ControlFlow::Continue(())) => std::ops::ControlFlow::Continue(Ok(())),
                 Ok(std::ops::ControlFlow::Break(())) => std::ops::ControlFlow::Break(()),
@@ -1260,10 +1251,10 @@ impl SharedState {
                 return Ok(None);
             };
             let roots = Self::roots_of(&project, &excluded);
-            let Some(()) = Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+            let Some(()) = Self::startup_apply_checkpointed_value(lease, |checkpoint| {
                 if let Err(error) = Self::configure_workspace_engine(
                     &mut engine,
-                    roots,
+                    roots.clone(),
                     BaselineHashMode::NormalizedChunks,
                 ) {
                     return std::ops::ControlFlow::Continue(Err(error));
@@ -1275,7 +1266,7 @@ impl SharedState {
             };
 
             let store = engine.store();
-            let Some(()) = Self::startup_apply_checkpointed_once(lease, |checkpoint| match store
+            let Some(()) = Self::startup_apply_checkpointed_value(lease, |checkpoint| match store
                 .clear_workspace_overlay_checkpointed("code", checkpoint)
             {
                 Ok(std::ops::ControlFlow::Continue(())) => std::ops::ControlFlow::Continue(Ok(())),
@@ -1324,7 +1315,7 @@ impl SharedState {
                         {
                             Ok(manifest) => {
                                 let manifest_files = manifest.files.len();
-                                match Self::startup_apply_checkpointed_once(lease, |checkpoint| {
+                                match Self::startup_apply_checkpointed_value(lease, |checkpoint| {
                                     match store
                                         .save_baseline_manifest_checkpointed(&manifest, checkpoint)
                                     {
@@ -1412,10 +1403,12 @@ impl SharedState {
         // a row surviving the local period would suppress a same-stat edit after a switch
         // back to the same snapshot. A failed clear leaves that lie standing, so the boot
         // fails closed, exactly like the Postgres branch does on its own failed clears.
-        let Some(()) = Self::startup_apply_checkpointed_once(lease, |checkpoint| {
-            if let Err(error) =
-                Self::configure_workspace_engine(&mut engine, roots, BaselineHashMode::RawFileBytes)
-            {
+        let Some(()) = Self::startup_apply_checkpointed_value(lease, |checkpoint| {
+            if let Err(error) = Self::configure_workspace_engine(
+                &mut engine,
+                roots.clone(),
+                BaselineHashMode::RawFileBytes,
+            ) {
                 return std::ops::ControlFlow::Continue(Err(error));
             }
             engine.set_serves_external_baseline_checkpointed(false, checkpoint)
@@ -1941,6 +1934,26 @@ mod tests {
         ));
         assert_eq!(clock.get().duration_since(started), std::time::Duration::from_secs(600));
         assert_eq!(attempts.get(), 301);
+    }
+
+    #[test]
+    fn checkpoint_refusal_retries_the_startup_transaction() {
+        let dir = tempdir().unwrap();
+        let lease = crate::workspace_lease::WorkspaceLease::claim(dir.path());
+        lease.fail_next_checkpoint_lock_for_test();
+        let mut attempts = 0_u8;
+
+        let result = SharedState::startup_apply_checkpointed_value(&lease, |checkpoint| {
+            attempts += 1;
+            if checkpoint().is_break() {
+                return std::ops::ControlFlow::Break(());
+            }
+            std::ops::ControlFlow::Continue(Ok(attempts))
+        })
+        .unwrap();
+
+        assert_eq!(result, Some(2));
+        assert_eq!(attempts, 2);
     }
 
     #[test]

--- a/crates/mcp-server/src/state/embed.rs
+++ b/crates/mcp-server/src/state/embed.rs
@@ -3392,7 +3392,7 @@ mod tests {
 
     #[test]
     fn failed_typed_preflight_makes_zero_network_calls() {
-        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _lock = env_lock();
         let _reset = ResetEmbeddingRefusals;
         let (server, calls) = spawn_counting_embedding_server();
         let dir = tempdir().unwrap();
@@ -3412,7 +3412,7 @@ mod tests {
 
     #[test]
     fn prepared_vectors_survive_transient_publish_without_second_call() {
-        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _lock = env_lock();
         let _reset = ResetEmbeddingRefusals;
         let (server, calls) = spawn_counting_embedding_server();
         let dir = tempdir().unwrap();
@@ -3436,7 +3436,7 @@ mod tests {
     fn prepared_index_survives_transient_swap_without_rebuild() {
         use super::EmbedFencePoint;
 
-        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _lock = env_lock();
         for request_rerun in [false, true] {
             let _reset = ResetEmbeddingRefusals;
             let (server, calls) = spawn_counting_embedding_server();
@@ -3512,7 +3512,7 @@ mod tests {
 
     #[test]
     fn publication_deadline_moves_runtime_to_failed() {
-        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _lock = env_lock();
         let _reset = ResetEmbeddingRefusals;
         let (server, _) = spawn_counting_embedding_server();
         let dir = tempdir().unwrap();

--- a/crates/mcp-server/src/state/embed.rs
+++ b/crates/mcp-server/src/state/embed.rs
@@ -1160,88 +1160,102 @@ impl SharedState {
                         },
                     ) {
                         Ok(bsl_search::FenceOutcome::Applied(index)) => {
-                            #[cfg(test)]
-                            if let Some(hook) = EMBED_FENCE_HOOK
-                                .lock()
-                                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                                .as_mut()
-                            {
-                                hook(EmbedFencePoint::Swap);
-                            }
                             let mut prepared_index = Some(index);
-                            let swapped = match engine.lock() {
-                                Ok(mut guard) => match guard.as_mut() {
-                                    Some(engine) => worker_lease.publish_short(
-                                        &mut prepared_index,
-                                        |prepared| {
-                                            engine.set_vector_index(
-                                                prepared.take().expect("prepared index exists"),
+                            // Retry only the swap: keep the built index and any pending rerun.
+                            loop {
+                                #[cfg(test)]
+                                if let Some(hook) = EMBED_FENCE_HOOK
+                                    .lock()
+                                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                    .as_mut()
+                                {
+                                    hook(EmbedFencePoint::Swap);
+                                }
+                                let swapped = match engine.lock() {
+                                    Ok(mut guard) => match guard.as_mut() {
+                                        Some(engine) => worker_lease.publish_short(
+                                            &mut prepared_index,
+                                            |prepared| {
+                                                engine.set_vector_index(
+                                                    prepared.take().expect("prepared index exists"),
+                                                );
+                                                Ok::<_, std::convert::Infallible>(())
+                                            },
+                                        ),
+                                        None => {
+                                            tracing::warn!("embedding pass: engine unavailable");
+                                            Self::set_semantic_runtime_status(
+                                                &runtime,
+                                                SemanticRuntimeStatus::Failed(
+                                                    "embedding engine unavailable".to_owned(),
+                                                ),
                                             );
-                                            Ok::<_, std::convert::Infallible>(())
-                                        },
-                                    ),
-                                    None => {
-                                        tracing::warn!("embedding pass: engine unavailable");
+                                            status_guard.finish();
+                                            return;
+                                        }
+                                    },
+                                    Err(e) => {
+                                        tracing::warn!("embedding pass: engine lock error: {e}");
+                                        Self::set_semantic_runtime_status(
+                                            &runtime,
+                                            SemanticRuntimeStatus::Failed(format!(
+                                                "embedding engine lock error: {e}"
+                                            )),
+                                        );
+                                        status_guard.finish();
+                                        return;
+                                    }
+                                };
+                                match swapped {
+                                    crate::workspace_lease::LeaseOperationOutcome::Applied(()) => {
+                                        #[cfg(test)]
+                                        {
+                                            let mut hook = EMBED_POST_PASS_HOOK
+                                                .lock()
+                                                .unwrap_or_else(|p| p.into_inner());
+                                            if let Some(h) = hook.as_mut() {
+                                                h(&db_path);
+                                            }
+                                        }
+                                        break;
+                                    }
+                                    crate::workspace_lease::LeaseOperationOutcome::TransientRefusal => {
+                                        let delay = super::overlay_retry::retry_delay(publish_retry.streak());
+                                        if let RetryDecision::RetryAfter(delay) =
+                                            publish_retry.refused(Instant::now(), delay)
+                                        {
+                                            std::thread::sleep(delay);
+                                            if !publish_retry.expired(Instant::now()) {
+                                                continue;
+                                            }
+                                        }
+                                        retry_refusal = true;
+                                        break;
+                                    }
+                                    crate::workspace_lease::LeaseOperationOutcome::Superseded
+                                    | crate::workspace_lease::LeaseOperationOutcome::Released => {
                                         Self::set_semantic_runtime_status(
                                             &runtime,
                                             SemanticRuntimeStatus::Failed(
-                                                "embedding engine unavailable".to_owned(),
+                                                "embedding stopped after workspace ownership was superseded"
+                                                    .to_owned(),
                                             ),
                                         );
                                         status_guard.finish();
                                         return;
                                     }
-                                },
-                                Err(e) => {
-                                    tracing::warn!("embedding pass: engine lock error: {e}");
-                                    Self::set_semantic_runtime_status(
-                                        &runtime,
-                                        SemanticRuntimeStatus::Failed(format!(
-                                            "embedding engine lock error: {e}"
-                                        )),
-                                    );
-                                    status_guard.finish();
-                                    return;
-                                }
-                            };
-                            match swapped {
-                                crate::workspace_lease::LeaseOperationOutcome::Applied(()) => {
-                                    #[cfg(test)]
-                                    {
-                                        let mut hook = EMBED_POST_PASS_HOOK
-                                            .lock()
-                                            .unwrap_or_else(|p| p.into_inner());
-                                        if let Some(h) = hook.as_mut() {
-                                            h(&db_path);
-                                        }
+                                    crate::workspace_lease::LeaseOperationOutcome::OperationError(
+                                        error,
+                                    ) => {
+                                        Self::set_semantic_runtime_status(
+                                            &runtime,
+                                            SemanticRuntimeStatus::Failed(format!(
+                                                "embedding publication failed: {error:?}"
+                                            )),
+                                        );
+                                        status_guard.finish();
+                                        return;
                                     }
-                                }
-                                crate::workspace_lease::LeaseOperationOutcome::TransientRefusal => {
-                                    retry_refusal = true;
-                                }
-                                crate::workspace_lease::LeaseOperationOutcome::Superseded
-                                | crate::workspace_lease::LeaseOperationOutcome::Released => {
-                                    Self::set_semantic_runtime_status(
-                                        &runtime,
-                                        SemanticRuntimeStatus::Failed(
-                                            "embedding stopped after workspace ownership was superseded"
-                                                .to_owned(),
-                                        ),
-                                    );
-                                    status_guard.finish();
-                                    return;
-                                }
-                                crate::workspace_lease::LeaseOperationOutcome::OperationError(
-                                    error,
-                                ) => {
-                                    Self::set_semantic_runtime_status(
-                                        &runtime,
-                                        SemanticRuntimeStatus::Failed(format!(
-                                            "embedding publication failed: {error:?}"
-                                        )),
-                                    );
-                                    status_guard.finish();
-                                    return;
                                 }
                             }
                         }
@@ -1370,6 +1384,7 @@ mod tests {
         fn drop(&mut self) {
             super::FORCE_EMBED_PREFLIGHT_REFUSALS.store(0, Ordering::SeqCst);
             super::FORCE_EMBED_PUBLICATION_REFUSALS.store(0, Ordering::SeqCst);
+            *super::EMBED_FENCE_HOOK.lock().unwrap_or_else(|p| p.into_inner()) = None;
         }
     }
 
@@ -3415,6 +3430,84 @@ mod tests {
             .load_pending_embedding_documents("code")
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn prepared_index_survives_transient_swap_without_rebuild() {
+        use super::EmbedFencePoint;
+
+        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        for request_rerun in [false, true] {
+            let _reset = ResetEmbeddingRefusals;
+            let (server, calls) = spawn_counting_embedding_server();
+            let dir = tempdir().unwrap();
+            let cache = crate::cache::WorkspaceCacheLayout::for_workspace(dir.path());
+            cache.ensure().unwrap();
+            let db_path = cache.search_db_path();
+            seed_pending_embedding(&db_path);
+            let engine = Arc::new(Mutex::new(Some(
+                SearchEngine::new(&db_path, mock_semantic_config(&server)).unwrap(),
+            )));
+            let runtime = Arc::new(Mutex::new(crate::state::SemanticRuntimeStatus::Indexing));
+            let flight = super::EmbedFlight::new();
+            let lease = crate::workspace_lease::WorkspaceLease::claim_cache(&cache);
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let observed = Arc::clone(&events);
+            let hook_lease = lease.clone();
+            let hook_flight = Arc::clone(&flight);
+            let mut held = None;
+            let mut swaps = 0;
+            *super::EMBED_FENCE_HOOK.lock().unwrap() = Some(Box::new(move |point| {
+                observed.lock().unwrap().push(point);
+                // Let a regressed rebuild finish so the event assertion diagnoses it directly.
+                if matches!(point, EmbedFencePoint::Apply(_)) {
+                    drop(held.take());
+                }
+                if point == EmbedFencePoint::Swap {
+                    swaps += 1;
+                    if swaps == 1 {
+                        held = Some(hook_lease.hold_file_lock_for_test());
+                        if request_rerun {
+                            assert!(!hook_flight.claim());
+                        }
+                    } else {
+                        drop(held.take());
+                    }
+                }
+            }));
+            SharedState::spawn_embed_pass(
+                Arc::clone(&engine),
+                Arc::clone(&runtime),
+                bsl_search::IndexProgress::new(),
+                Arc::clone(&flight),
+                lease.clone(),
+                db_path,
+                mock_semantic_config(&server),
+                Duration::from_secs(10),
+            );
+            wait_for_embed_flight(&flight);
+
+            assert!(matches!(*runtime.lock().unwrap(), crate::state::SemanticRuntimeStatus::Ready));
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+            assert_eq!(engine.lock().unwrap().as_ref().unwrap().vector_count(), 1);
+            let events = events.lock().unwrap();
+            let swaps: Vec<_> = events
+                .iter()
+                .enumerate()
+                .filter_map(|(i, point)| (*point == EmbedFencePoint::Swap).then_some(i))
+                .collect();
+            assert_eq!(
+                swaps.len(),
+                2 + usize::from(request_rerun),
+                "fresh work must survive retry"
+            );
+            assert_eq!(
+                swaps[1],
+                swaps[0] + 1,
+                "retry must not re-enter embedding or sidecar publication"
+            );
+            lease.release();
+        }
     }
 
     #[test]

--- a/crates/mcp-server/src/state/embed.rs
+++ b/crates/mcp-server/src/state/embed.rs
@@ -1,4 +1,4 @@
-use super::overlay_retry::PublishRetryWindow;
+use super::retry_window::{RetryDecision, RetryOwner, RetryWindow};
 use super::types::{OverlayWarmupState, SemanticRuntimeStatus, SharedSearchEngine};
 use super::SharedState;
 use bsl_search::{IndexProgress, SearchEngine, WorkspaceRootsTransitionOutcome};
@@ -202,6 +202,10 @@ type EmbedFenceHook = Box<dyn FnMut(EmbedFencePoint) + Send>;
 #[cfg(test)]
 static EMBED_FENCE_HOOK: Mutex<Option<EmbedFenceHook>> = Mutex::new(None);
 #[cfg(test)]
+static FORCE_EMBED_PREFLIGHT_REFUSALS: AtomicU64 = AtomicU64::new(0);
+#[cfg(test)]
+static FORCE_EMBED_PUBLICATION_REFUSALS: AtomicU64 = AtomicU64::new(0);
+#[cfg(test)]
 pub(super) static FORCE_OVERLAY_PUBLICATION_REFUSALS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
@@ -342,7 +346,8 @@ impl SharedState {
                     (false, false, false)
                 }
                 super::WorkspaceSearchApply::TransientRefusal
-                | super::WorkspaceSearchApply::Terminal => (false, false, false),
+                | super::WorkspaceSearchApply::Superseded
+                | super::WorkspaceSearchApply::Released => (false, false, false),
             };
         };
         // Fence the complete off-lock preparation, not only its second validation pass. Metadata
@@ -458,7 +463,8 @@ impl SharedState {
                 return (false, false, false);
             }
             super::WorkspaceSearchApply::TransientRefusal
-            | super::WorkspaceSearchApply::Terminal => return (false, false, false),
+            | super::WorkspaceSearchApply::Superseded
+            | super::WorkspaceSearchApply::Released => return (false, false, false),
         };
         match outcome {
             WorkspaceRootsTransitionOutcome::Unchanged => (true, false, false),
@@ -552,7 +558,9 @@ impl SharedState {
                             overlay_warmup,
                             OverlayWarmupState::Skipped("no embedder configured".to_owned()),
                         );
-                        return super::WorkspaceSearchApply::Terminal;
+                        return super::WorkspaceSearchApply::Applied(OverlayWarmupState::Skipped(
+                            "no embedder configured".to_owned(),
+                        ));
                     };
                     let Some(roots) = engine.workspace_roots().cloned() else {
                         tracing::debug!("overlay warmup: no workspace root; skipping");
@@ -560,7 +568,9 @@ impl SharedState {
                             overlay_warmup,
                             OverlayWarmupState::Skipped("no workspace root".to_owned()),
                         );
-                        return super::WorkspaceSearchApply::Terminal;
+                        return super::WorkspaceSearchApply::Applied(OverlayWarmupState::Skipped(
+                            "no workspace root".to_owned(),
+                        ));
                     };
                     let warm_cache = match engine.workspace_overlay_embedding_cache_snapshot() {
                         Ok(cache) => cache,
@@ -631,7 +641,7 @@ impl SharedState {
         // verdict would let a superseded daemon write for up to its TTL after a takeover),
         // and the caller's own stop signal rides along: a shutdown mid-batch must not keep
         // writing the shared table while the lease is being handed over.
-        let should_continue = || lease.owns_caches_now() && keep_going();
+        let should_continue = || keep_going();
         let planning_distrusted = dirty_before.retry_distrusted();
         let primed = SearchEngine::prime_workspace_overlay_standalone_retrying(
             &db_path,
@@ -640,7 +650,7 @@ impl SharedState {
             warm_cache,
             graph_provider,
             &should_continue,
-            |operation| Self::search_fence_outcome(lease.with_ownership_outcome(operation)),
+            |operation| Self::search_fence_outcome(lease.publish_short(&mut (), |_| operation())),
             &planning_distrusted,
             &mut *retry_transient,
         );
@@ -650,13 +660,17 @@ impl SharedState {
                 tracing::warn!("workspace overlay semantic warmup temporarily refused");
                 return super::WorkspaceSearchApply::TransientRefusal;
             }
-            Ok(bsl_search::FenceOutcome::Terminal) => {
+            Ok(bsl_search::FenceOutcome::Superseded) => {
                 tracing::warn!("workspace overlay semantic warmup stopped");
                 Self::set_overlay_warmup_state(
                     overlay_warmup,
                     OverlayWarmupState::Failed("workspace ownership lost at publish".to_owned()),
                 );
-                return super::WorkspaceSearchApply::Terminal;
+                return super::WorkspaceSearchApply::Superseded;
+            }
+            Ok(bsl_search::FenceOutcome::Released) => {
+                tracing::warn!("workspace overlay semantic warmup released");
+                return super::WorkspaceSearchApply::Released;
             }
             Err(error) => {
                 tracing::warn!("workspace overlay semantic warmup failed: {error}");
@@ -683,7 +697,7 @@ impl SharedState {
                 overlay_warmup,
                 OverlayWarmupState::Failed("workspace ownership lost at publish".to_owned()),
             );
-            return super::WorkspaceSearchApply::Terminal;
+            return super::WorkspaceSearchApply::Released;
         }
         let mut prepared = match search_engine.lock() {
             Ok(guard) => match guard.as_ref() {
@@ -715,7 +729,7 @@ impl SharedState {
         };
         let published = loop {
             if !keep_going() {
-                return super::WorkspaceSearchApply::Terminal;
+                return super::WorkspaceSearchApply::Released;
             }
             #[cfg(test)]
             if FORCE_OVERLAY_PUBLICATION_REFUSALS
@@ -741,14 +755,17 @@ impl SharedState {
                 super::WorkspaceSearchApply::TransientRefusal => {
                     return super::WorkspaceSearchApply::TransientRefusal
                 }
-                super::WorkspaceSearchApply::Terminal => {
+                super::WorkspaceSearchApply::Superseded => {
                     Self::set_overlay_warmup_state(
                         overlay_warmup,
                         OverlayWarmupState::Failed(
                             "workspace ownership lost at publish".to_owned(),
                         ),
                     );
-                    return super::WorkspaceSearchApply::Terminal;
+                    return super::WorkspaceSearchApply::Superseded;
+                }
+                super::WorkspaceSearchApply::Released => {
+                    return super::WorkspaceSearchApply::Released;
                 }
                 super::WorkspaceSearchApply::OperationError(error) => break Err(error),
             }
@@ -910,7 +927,7 @@ impl SharedState {
                         (),
                         Result<(), bsl_search::SearchError>,
                     >| {
-                        Self::search_fence_outcome(lease.with_ownership_checkpointed(operation))
+                        Self::search_fence_outcome(lease.publish_checkpointed(operation))
                     };
                     engine.refresh_dirty_contexts_fenced(
                         &provider,
@@ -952,7 +969,12 @@ impl SharedState {
         // Re-rendered chunks had their live embedding NULLed; without a re-embed they serve
         // the OLD vector in-process and vanish from semantic results after a restart until
         // the boot pass. Kick the same background embed machinery workspace init uses.
-        if stats.cleared_embeddings > 0 && !matches!(outcome, bsl_search::FenceOutcome::Terminal) {
+        if stats.cleared_embeddings > 0
+            && !matches!(
+                outcome,
+                bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released
+            )
+        {
             Self::kick_context_reembed(
                 engine,
                 semantic_runtime,
@@ -1068,7 +1090,8 @@ impl SharedState {
                 let mut status_guard = EmbedStatusGuard::new(Arc::clone(&runtime));
                 #[cfg(test)]
                 let mut apply_count = 0usize;
-                let mut publish_retry = PublishRetryWindow::default();
+                let mut publish_retry =
+                    RetryWindow::with_budget(RetryOwner::OverlayEmbedding, publish_retry_budget);
                 tracing::info!(
                     publish_retry_budget_secs = publish_retry_budget.as_secs(),
                     "background embedding pass started"
@@ -1106,15 +1129,31 @@ impl SharedState {
                                 {
                                     hook(EmbedFencePoint::Apply(apply_count));
                                 }
+                                let forced = if apply_count == 1 {
+                                    &FORCE_EMBED_PREFLIGHT_REFUSALS
+                                } else {
+                                    &FORCE_EMBED_PUBLICATION_REFUSALS
+                                };
+                                if forced
+                                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                                        remaining.checked_sub(1)
+                                    })
+                                    .is_ok()
+                                {
+                                    return bsl_search::FenceOutcome::TransientRefusal;
+                                }
                             }
                             Self::search_fence_outcome(
-                                worker_lease.with_ownership_outcome(operation),
+                                worker_lease.publish_short(&mut (), |_| operation()),
                             )
                         },
                         || {
                             let now = Instant::now();
-                            let Some(delay) = publish_retry.refused(now, publish_retry_budget) else {
-                                return false;
+                            let bounded_delay =
+                                super::overlay_retry::retry_delay(publish_retry.streak());
+                            let delay = match publish_retry.refused(now, bounded_delay) {
+                                RetryDecision::RetryAfter(delay) => delay,
+                                RetryDecision::Stop(_) => return false,
                             };
                             std::thread::sleep(delay);
                             !publish_retry.expired(Instant::now())
@@ -1129,11 +1168,18 @@ impl SharedState {
                             {
                                 hook(EmbedFencePoint::Swap);
                             }
+                            let mut prepared_index = Some(index);
                             let swapped = match engine.lock() {
                                 Ok(mut guard) => match guard.as_mut() {
-                                    Some(engine) => worker_lease.with_ownership_outcome(|| {
-                                        engine.set_vector_index(index)
-                                    }),
+                                    Some(engine) => worker_lease.publish_short(
+                                        &mut prepared_index,
+                                        |prepared| {
+                                            engine.set_vector_index(
+                                                prepared.take().expect("prepared index exists"),
+                                            );
+                                            Ok::<_, std::convert::Infallible>(())
+                                        },
+                                    ),
                                     None => {
                                         tracing::warn!("embedding pass: engine unavailable");
                                         Self::set_semantic_runtime_status(
@@ -1159,7 +1205,7 @@ impl SharedState {
                                 }
                             };
                             match swapped {
-                                crate::workspace_lease::LeaseOutcome::Applied(()) => {
+                                crate::workspace_lease::LeaseOperationOutcome::Applied(()) => {
                                     #[cfg(test)]
                                     {
                                         let mut hook = EMBED_POST_PASS_HOOK
@@ -1170,10 +1216,11 @@ impl SharedState {
                                         }
                                     }
                                 }
-                                crate::workspace_lease::LeaseOutcome::TransientRefusal => {
+                                crate::workspace_lease::LeaseOperationOutcome::TransientRefusal => {
                                     retry_refusal = true;
                                 }
-                                crate::workspace_lease::LeaseOutcome::Terminal => {
+                                crate::workspace_lease::LeaseOperationOutcome::Superseded
+                                | crate::workspace_lease::LeaseOperationOutcome::Released => {
                                     Self::set_semantic_runtime_status(
                                         &runtime,
                                         SemanticRuntimeStatus::Failed(
@@ -1184,12 +1231,27 @@ impl SharedState {
                                     status_guard.finish();
                                     return;
                                 }
+                                crate::workspace_lease::LeaseOperationOutcome::OperationError(
+                                    error,
+                                ) => {
+                                    Self::set_semantic_runtime_status(
+                                        &runtime,
+                                        SemanticRuntimeStatus::Failed(format!(
+                                            "embedding publication failed: {error:?}"
+                                        )),
+                                    );
+                                    status_guard.finish();
+                                    return;
+                                }
                             }
                         }
                         Ok(bsl_search::FenceOutcome::TransientRefusal) => {
                             retry_refusal = true;
                         }
-                        Ok(bsl_search::FenceOutcome::Terminal) => {
+                        Ok(
+                            bsl_search::FenceOutcome::Superseded
+                            | bsl_search::FenceOutcome::Released,
+                        ) => {
                             Self::set_semantic_runtime_status(
                                 &runtime,
                                 SemanticRuntimeStatus::Failed(
@@ -1213,12 +1275,13 @@ impl SharedState {
                         }
                     }
                     let retry_wait = if retry_refusal {
-                        match publish_retry.refused(Instant::now(), publish_retry_budget) {
-                            Some(delay) => {
+                        let delay = super::overlay_retry::retry_delay(publish_retry.streak());
+                        match publish_retry.refused(Instant::now(), delay) {
+                            RetryDecision::RetryAfter(delay) => {
                                 let _ = flight.claim();
                                 Some(delay)
                             }
-                            None => {
+                            RetryDecision::Stop(_) => {
                                 Self::set_semantic_runtime_status(
                                     &runtime,
                                     SemanticRuntimeStatus::Failed(
@@ -1230,7 +1293,7 @@ impl SharedState {
                             }
                         }
                     } else {
-                        publish_retry.reset();
+                        publish_retry.complete();
                         None
                     };
                     if !flight.finish_pass() {
@@ -1300,6 +1363,133 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tempfile::tempdir;
+
+    struct ResetEmbeddingRefusals;
+
+    impl Drop for ResetEmbeddingRefusals {
+        fn drop(&mut self) {
+            super::FORCE_EMBED_PREFLIGHT_REFUSALS.store(0, Ordering::SeqCst);
+            super::FORCE_EMBED_PUBLICATION_REFUSALS.store(0, Ordering::SeqCst);
+        }
+    }
+
+    fn seed_pending_embedding(path: &std::path::Path) {
+        use bsl_search::{Chunk, ChunkKind, Store};
+
+        Store::open(path)
+            .unwrap()
+            .reindex_file_with_context(
+                bsl_search::CONFIGURATION_ROOT_ID,
+                "A.bsl",
+                b"h",
+                &[Chunk {
+                    kind: ChunkKind::Procedure,
+                    name: "Альфа".to_owned(),
+                    is_export: true,
+                    annotations: Vec::new(),
+                    line_start: 0,
+                    line_end: 1,
+                    text: "Процедура Альфа()\nКонецПроцедуры".to_owned(),
+                }],
+                None,
+                Some(&[None]),
+            )
+            .unwrap();
+    }
+
+    fn wait_for_embed_flight(flight: &super::EmbedFlight) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while flight.is_in_flight() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!flight.is_in_flight(), "embedding pass did not finish");
+    }
+
+    fn spawn_counting_embedding_server() -> (String, Arc<AtomicUsize>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&calls);
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut request = Vec::new();
+                let mut chunk = [0; 2048];
+                let mut header_end = None;
+                let mut content_len = 0;
+                while let Ok(read) = stream.read(&mut chunk) {
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&chunk[..read]);
+                    if header_end.is_none() {
+                        if let Some(end) = request.windows(4).position(|part| part == b"\r\n\r\n") {
+                            header_end = Some(end + 4);
+                            let headers = String::from_utf8_lossy(&request[..end]).to_lowercase();
+                            content_len = headers
+                                .lines()
+                                .find_map(|line| line.strip_prefix("content-length:"))
+                                .and_then(|value| value.trim().parse().ok())
+                                .unwrap_or(0);
+                        }
+                    }
+                    if header_end.is_some_and(|end| request.len() >= end + content_len) {
+                        break;
+                    }
+                }
+                observed.fetch_add(1, Ordering::SeqCst);
+                let inputs = header_end
+                    .and_then(|end| {
+                        serde_json::from_slice::<serde_json::Value>(&request[end..]).ok()
+                    })
+                    .and_then(|value| value.get("input")?.as_array().map(Vec::len))
+                    .unwrap_or(1);
+                let data: Vec<_> = (0..inputs)
+                    .map(|index| serde_json::json!({"index": index, "embedding": [1.0, 0.0, 0.0]}))
+                    .collect();
+                let body = serde_json::json!({"data": data}).to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(), body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        (format!("http://{addr}"), calls)
+    }
+
+    fn start_test_embed(
+        cache: &crate::cache::WorkspaceCacheLayout,
+        server: &str,
+        budget: Duration,
+    ) -> (
+        super::SharedSearchEngine,
+        Arc<Mutex<crate::state::SemanticRuntimeStatus>>,
+        Arc<super::EmbedFlight>,
+    ) {
+        cache.ensure().unwrap();
+        let db_path = cache.search_db_path();
+        seed_pending_embedding(&db_path);
+        let engine = Arc::new(Mutex::new(Some(
+            SearchEngine::new(&db_path, mock_semantic_config(server)).unwrap(),
+        )));
+        let runtime = Arc::new(Mutex::new(crate::state::SemanticRuntimeStatus::Indexing));
+        let flight = super::EmbedFlight::new();
+        SharedState::spawn_embed_pass(
+            Arc::clone(&engine),
+            Arc::clone(&runtime),
+            bsl_search::IndexProgress::new(),
+            Arc::clone(&flight),
+            crate::workspace_lease::WorkspaceLease::claim_cache(cache),
+            db_path,
+            mock_semantic_config(server),
+            budget,
+        );
+        (engine, runtime, flight)
+    }
 
     /// The extension topology recorded in the graph database a test just built — what a real
     /// publish would put in its signal, and what the refresh checks the file against.
@@ -3183,6 +3373,67 @@ mod tests {
             std::thread::sleep(Duration::from_millis(50));
         }
         assert!(both, "the rerun loop embedded the chunk created after the pass started");
+    }
+
+    #[test]
+    fn failed_typed_preflight_makes_zero_network_calls() {
+        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _reset = ResetEmbeddingRefusals;
+        let (server, calls) = spawn_counting_embedding_server();
+        let dir = tempdir().unwrap();
+        let cache = crate::cache::WorkspaceCacheLayout::for_workspace(dir.path());
+        super::FORCE_EMBED_PREFLIGHT_REFUSALS.store(1, Ordering::SeqCst);
+
+        let (_, runtime, flight) = start_test_embed(&cache, &server, Duration::ZERO);
+        wait_for_embed_flight(&flight);
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(matches!(
+            &*runtime.lock().unwrap(),
+            crate::state::SemanticRuntimeStatus::Failed(message)
+                if message.contains("retry budget exhausted")
+        ));
+    }
+
+    #[test]
+    fn prepared_vectors_survive_transient_publish_without_second_call() {
+        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _reset = ResetEmbeddingRefusals;
+        let (server, calls) = spawn_counting_embedding_server();
+        let dir = tempdir().unwrap();
+        let cache = crate::cache::WorkspaceCacheLayout::for_workspace(dir.path());
+        super::FORCE_EMBED_PUBLICATION_REFUSALS.store(1, Ordering::SeqCst);
+
+        let (engine, runtime, flight) = start_test_embed(&cache, &server, Duration::from_secs(1));
+        wait_for_embed_flight(&flight);
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(matches!(*runtime.lock().unwrap(), crate::state::SemanticRuntimeStatus::Ready));
+        assert_eq!(engine.lock().unwrap().as_ref().unwrap().vector_count(), 1);
+        assert!(bsl_search::Store::open_existing(&cache.search_db_path())
+            .unwrap()
+            .load_pending_embedding_documents("code")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn publication_deadline_moves_runtime_to_failed() {
+        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _reset = ResetEmbeddingRefusals;
+        let (server, _) = spawn_counting_embedding_server();
+        let dir = tempdir().unwrap();
+        let cache = crate::cache::WorkspaceCacheLayout::for_workspace(dir.path());
+        super::FORCE_EMBED_PREFLIGHT_REFUSALS.store(1, Ordering::SeqCst);
+
+        let (_, runtime, flight) = start_test_embed(&cache, &server, Duration::ZERO);
+        wait_for_embed_flight(&flight);
+
+        assert!(matches!(
+            &*runtime.lock().unwrap(),
+            crate::state::SemanticRuntimeStatus::Failed(message)
+                if message.contains("retry budget exhausted")
+        ));
     }
 
     #[test]

--- a/crates/mcp-server/src/state/mod.rs
+++ b/crates/mcp-server/src/state/mod.rs
@@ -271,16 +271,12 @@ impl SharedState {
     /// carries, joined for one status line — the state in which valid calls into
     /// that configuration are reported as unresolved. An extension's and an
     /// external object's are distinct conditions and both can hold at once.
-    /// Derived from the project as it is now, not from the root captured at
-    /// bootstrap: a config edit can move the resolved root between a main
-    /// configuration and an extension, and everything else — diagnostics, graph,
-    /// drift — already rebuilds through `crate::project::at` when it does.
+    /// Captured at bootstrap and refreshed by rebuilding the workspace state.
     pub(crate) fn standalone_notice(&self) -> Option<String> {
         self.standalone_notice.clone()
     }
 
     pub(crate) fn superseded(&self) -> bool {
-        let _ = self.workspace_lease.owns_caches();
         self.workspace_lease.is_superseded()
     }
 
@@ -599,10 +595,27 @@ mod tests {
         state.workspace_lease = old.clone();
         let newer = crate::workspace_lease::WorkspaceLease::claim(terminal_dir.path());
         old.invalidate_verdict_for_test();
+        assert!(!state.superseded(), "the cached view performs no ownership refresh");
+        assert!(!old.owns_caches(), "the heartbeat-owned refresh observes takeover");
         assert!(state.superseded(), "the refreshed live foreign token is terminal");
         newer.release();
         assert!(state.superseded(), "owner release cannot clear the terminal flag");
         assert!(!state.owns_caches());
+    }
+
+    #[test]
+    fn superseded_check_never_waits_for_the_lease_lifecycle_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = crate::workspace_lease::WorkspaceLease::claim(dir.path());
+        let mut state = SharedState::shared();
+        state.workspace_lease = lease.clone();
+        let held = lease.hold_lifecycle_lock_for_test();
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || tx.send(state.superseded()).unwrap());
+
+        assert!(!rx.recv_timeout(std::time::Duration::from_millis(100)).unwrap());
+        drop(held);
     }
 }
 

--- a/crates/mcp-server/src/state/mod.rs
+++ b/crates/mcp-server/src/state/mod.rs
@@ -2,6 +2,7 @@ mod bootstrap;
 pub use bootstrap::WorkspaceInitError;
 mod embed;
 mod overlay_retry;
+pub(crate) mod retry_window;
 mod sync;
 #[cfg(test)]
 pub(crate) mod test_support;
@@ -47,13 +48,15 @@ pub(crate) struct ReferenceSearchState {
 /// dirty and are served by the query's own lazy disk refresh and by subsequent queries' prefetch
 /// passes, so nothing is lost — the cap is purely a per-query budget. 64 keeps the pre-pass cheap
 /// while covering the common "edit a handful of files, then search" case in one shot.
+#[cfg(test)]
 const MAX_RESIDENT_PREFETCH_PATHS_PER_QUERY: usize = 64;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum WorkspaceSearchApply<T, E> {
     Applied(T),
     TransientRefusal,
-    Terminal,
+    Superseded,
+    Released,
     OperationError(E),
 }
 
@@ -64,6 +67,7 @@ pub struct SharedState {
     /// which may be nested under `workspace_root`. File-tree lookups such as
     /// `metadata(form)` resolve object directories relative to THIS root, not the repo root.
     source_root: Option<PathBuf>,
+    standalone_notice: Option<String>,
     onec_client: Option<OnecClient>,
     onec_connections: BTreeMap<String, OnecConnection>,
     debug_session: Arc<Mutex<Option<bsl_debug::session::DebugSession>>>,
@@ -133,16 +137,28 @@ impl OnecConnection {
 
 impl SharedState {
     pub(super) fn search_fence_outcome<T>(
-        outcome: crate::workspace_lease::LeaseOutcome<T>,
-    ) -> bsl_search::FenceOutcome<T> {
+        outcome: crate::workspace_lease::LeaseOperationOutcome<T, bsl_search::SearchError>,
+    ) -> bsl_search::FenceOutcome<Result<T, bsl_search::SearchError>> {
         match outcome {
-            crate::workspace_lease::LeaseOutcome::Applied(value) => {
-                bsl_search::FenceOutcome::Applied(value)
+            crate::workspace_lease::LeaseOperationOutcome::Applied(value) => {
+                bsl_search::FenceOutcome::Applied(Ok(value))
             }
-            crate::workspace_lease::LeaseOutcome::TransientRefusal => {
+            crate::workspace_lease::LeaseOperationOutcome::OperationError(error) => {
+                let error = match error {
+                    crate::workspace_lease::LeaseOperationError::Lease(error) => error.into(),
+                    crate::workspace_lease::LeaseOperationError::Operation(error) => error,
+                };
+                bsl_search::FenceOutcome::Applied(Err(error))
+            }
+            crate::workspace_lease::LeaseOperationOutcome::TransientRefusal => {
                 bsl_search::FenceOutcome::TransientRefusal
             }
-            crate::workspace_lease::LeaseOutcome::Terminal => bsl_search::FenceOutcome::Terminal,
+            crate::workspace_lease::LeaseOperationOutcome::Superseded => {
+                bsl_search::FenceOutcome::Superseded
+            }
+            crate::workspace_lease::LeaseOperationOutcome::Released => {
+                bsl_search::FenceOutcome::Released
+            }
         }
     }
 
@@ -151,9 +167,39 @@ impl SharedState {
         lease: &crate::workspace_lease::WorkspaceLease,
         apply: impl FnOnce(&mut bsl_search::SearchEngine) -> Result<T, bsl_search::SearchError>,
     ) -> WorkspaceSearchApply<T, bsl_search::SearchError> {
-        Self::apply_workspace_search_checkpointed(shared, lease, |engine, _checkpoint| {
-            std::ops::ControlFlow::Continue(apply(engine))
-        })
+        let mut guard = match shared.lock() {
+            Ok(guard) => guard,
+            Err(error) => {
+                return WorkspaceSearchApply::OperationError(bsl_search::SearchError::Index(
+                    format!("workspace search engine lock poisoned: {error}"),
+                ));
+            }
+        };
+        let Some(engine) = guard.as_mut() else {
+            return WorkspaceSearchApply::OperationError(bsl_search::SearchError::Index(
+                "workspace search engine is not published".to_owned(),
+            ));
+        };
+        match lease.publish_short(&mut (), |_| apply(engine)) {
+            crate::workspace_lease::LeaseOperationOutcome::Applied(result) => {
+                WorkspaceSearchApply::Applied(result)
+            }
+            crate::workspace_lease::LeaseOperationOutcome::OperationError(error) => {
+                WorkspaceSearchApply::OperationError(match error {
+                    crate::workspace_lease::LeaseOperationError::Lease(error) => error.into(),
+                    crate::workspace_lease::LeaseOperationError::Operation(error) => error,
+                })
+            }
+            crate::workspace_lease::LeaseOperationOutcome::TransientRefusal => {
+                WorkspaceSearchApply::TransientRefusal
+            }
+            crate::workspace_lease::LeaseOperationOutcome::Superseded => {
+                WorkspaceSearchApply::Superseded
+            }
+            crate::workspace_lease::LeaseOperationOutcome::Released => {
+                WorkspaceSearchApply::Released
+            }
+        }
     }
 
     pub(super) fn apply_workspace_search_checkpointed<T>(
@@ -191,17 +237,25 @@ impl SharedState {
                 "workspace search engine is not published".to_owned(),
             ));
         };
-        match lease.with_ownership_checkpointed(|checkpoint| apply(engine, checkpoint)) {
-            crate::workspace_lease::LeaseOutcome::Applied(Ok(result)) => {
+        match lease.publish_checkpointed(|checkpoint| apply(engine, checkpoint)) {
+            crate::workspace_lease::LeaseOperationOutcome::Applied(result) => {
                 WorkspaceSearchApply::Applied(result)
             }
-            crate::workspace_lease::LeaseOutcome::Applied(Err(error)) => {
-                WorkspaceSearchApply::OperationError(error)
+            crate::workspace_lease::LeaseOperationOutcome::OperationError(error) => {
+                WorkspaceSearchApply::OperationError(match error {
+                    crate::workspace_lease::LeaseOperationError::Lease(error) => error.into(),
+                    crate::workspace_lease::LeaseOperationError::Operation(error) => error,
+                })
             }
-            crate::workspace_lease::LeaseOutcome::TransientRefusal => {
+            crate::workspace_lease::LeaseOperationOutcome::TransientRefusal => {
                 WorkspaceSearchApply::TransientRefusal
             }
-            crate::workspace_lease::LeaseOutcome::Terminal => WorkspaceSearchApply::Terminal,
+            crate::workspace_lease::LeaseOperationOutcome::Superseded => {
+                WorkspaceSearchApply::Superseded
+            }
+            crate::workspace_lease::LeaseOperationOutcome::Released => {
+                WorkspaceSearchApply::Released
+            }
         }
     }
 
@@ -222,14 +276,7 @@ impl SharedState {
     /// configuration and an extension, and everything else — diagnostics, graph,
     /// drift — already rebuilds through `crate::project::at` when it does.
     pub(crate) fn standalone_notice(&self) -> Option<String> {
-        let root = self.workspace_root.as_deref()?;
-        let project = crate::project::at(root).ok()?;
-        let notices: Vec<String> =
-            [project.standalone_extension_notice(), project.standalone_external_notice()]
-                .into_iter()
-                .flatten()
-                .collect();
-        (!notices.is_empty()).then(|| notices.join("\n"))
+        self.standalone_notice.clone()
     }
 
     pub(crate) fn superseded(&self) -> bool {
@@ -237,6 +284,7 @@ impl SharedState {
         self.workspace_lease.is_superseded()
     }
 
+    #[cfg(test)]
     pub(crate) fn owns_caches(&self) -> bool {
         self.workspace_lease.owns_caches()
     }
@@ -258,6 +306,11 @@ impl SharedState {
             || self.index_progress.is_active()
             || self.embed_flight.is_in_flight()
             || self.overlay_retry.as_ref().is_some_and(|retry| retry.pass_active())
+    }
+
+    /// Cached request-path view backed only by lease atomics.
+    pub(crate) fn owns_caches_cached(&self) -> bool {
+        self.workspace_lease.owns_caches_cached()
     }
 
     /// Start building the diagnostics resident now instead of on the first tool call.
@@ -367,10 +420,18 @@ impl SharedState {
         Arc::clone(&self.overlay_warmup)
     }
 
+    /// Coalesce a request-observed stale resident into the existing background owner.
+    pub(crate) fn request_overlay_refresh(&self) {
+        if let Some(retry) = &self.overlay_retry {
+            retry.kick_fresh();
+        }
+    }
+
     pub(crate) fn workspace_search_mode(&self) -> WorkspaceSearchMode {
         self.workspace_search_mode.clone()
     }
 
+    #[cfg(test)]
     pub(crate) fn workspace_lease(&self) -> &crate::workspace_lease::WorkspaceLease {
         &self.workspace_lease
     }
@@ -431,10 +492,7 @@ impl SharedState {
     /// lock that only touches the overlay cache (never the resident). A resident that is
     /// absent/loading, or a path it cannot serve, is simply missing from the map and the
     /// reindex disk-reads it — so search never regresses when the resident is unavailable.
-    ///
-    /// Runs on behalf of one request: both engine-lock acquisitions and the per-path
-    /// resident reads observe `cancel`, and a cancelled request withdraws with whatever
-    /// remains left dirty, exactly as the per-query cap leaves it.
+    #[cfg(test)]
     pub(crate) fn prefetch_resident_overlay_fenced(
         engine: &SharedSearchEngine,
         lease: &crate::workspace_lease::WorkspaceLease,
@@ -608,7 +666,7 @@ mod standalone_extension_tests {
     }
 
     #[test]
-    fn the_notice_follows_a_config_edit_that_moves_the_root() {
+    fn the_notice_is_cached_for_request_status() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         configuration(root, "cf", false);
@@ -619,17 +677,11 @@ mod standalone_extension_tests {
         let state = SharedState::workspace(root.to_path_buf()).unwrap();
         assert!(state.standalone_notice().is_none(), "a main configuration stays silent");
 
-        // Everything else — diagnostics, graph, drift — rebuilds through
-        // `crate::project::at` after a config edit, so a notice read from the
-        // root captured at bootstrap would describe a project no longer in use.
         std::fs::write(&config, "[source]\nroot = \"ext\"\nextensions = []\n").unwrap();
-        assert!(
-            state.standalone_notice().is_some(),
-            "the root is now an extension and the notice must follow"
-        );
+        assert!(state.standalone_notice().is_none(), "request status does not reparse the project");
 
-        std::fs::write(&config, "[source]\nroot = \"cf\"\nextensions = []\n").unwrap();
-        assert!(state.standalone_notice().is_none(), "and must go away again");
+        let extension = SharedState::workspace(root.to_path_buf()).unwrap();
+        assert!(extension.standalone_notice().is_some());
     }
 }
 

--- a/crates/mcp-server/src/state/overlay_retry.rs
+++ b/crates/mcp-server/src/state/overlay_retry.rs
@@ -8,6 +8,7 @@
 //! bounded deadline; an operation failure waits for a new signal, while an incomplete scan or
 //! internally superseded overlay plan keeps the obligation alive.
 
+use super::retry_window::{RetryDecision, RetryOwner, RetryWindow};
 use super::types::{OverlayWarmupState, SemanticRuntimeStatus, SharedSearchEngine};
 use crate::workspace_lease::WorkspaceLease;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -32,32 +33,6 @@ pub(super) fn retry_delay(streak: u32) -> Duration {
         return Duration::ZERO;
     }
     TICK.checked_mul(1u32 << streak.min(6).saturating_sub(1)).map(|d| d.min(CAP)).unwrap_or(CAP)
-}
-
-#[derive(Default)]
-pub(super) struct PublishRetryWindow {
-    deadline: Option<Instant>,
-    streak: u32,
-}
-
-impl PublishRetryWindow {
-    pub(super) fn expired(&self, now: Instant) -> bool {
-        self.deadline.is_some_and(|deadline| now >= deadline)
-    }
-
-    pub(super) fn refused(&mut self, now: Instant, budget: Duration) -> Option<Duration> {
-        let deadline = *self.deadline.get_or_insert_with(|| now.checked_add(budget).unwrap_or(now));
-        if now >= deadline {
-            return None;
-        }
-        let delay = retry_delay(self.streak).min(deadline - now);
-        self.streak = self.streak.saturating_add(1);
-        Some(delay)
-    }
-
-    pub(super) fn reset(&mut self) {
-        *self = Self::default();
-    }
 }
 
 struct RetryState {
@@ -297,9 +272,7 @@ impl OverlayRetry {
     /// signal. An unpublished engine reads as "due" — the pass classifies it (a transient
     /// `Skipped` before the async init publishes, a backoff-paced retry after).
     fn should_run(&self, obligation: bool) -> bool {
-        if !self.lease.owns_caches_now() {
-            // A transient UNCLAIMED/lock refusal retries; the caller separately disarms only
-            // when this fresh check latched an irreversible foreign-owner observation.
+        if self.lease.is_superseded() {
             return false;
         }
         if obligation {
@@ -345,7 +318,8 @@ impl OverlayRetry {
             );
         }
         let stop = &self.stop;
-        let mut publish_retry = PublishRetryWindow::default();
+        let mut publish_retry =
+            RetryWindow::with_budget(RetryOwner::OverlayEmbedding, self.publish_retry_budget);
         let mut budget_exhausted = false;
         let mut outcome = super::SharedState::run_overlay_warmup(
             &self.engine,
@@ -354,9 +328,13 @@ impl OverlayRetry {
             &|| !stop.load(Ordering::SeqCst),
             &mut || {
                 let now = Instant::now();
-                let Some(delay) = publish_retry.refused(now, self.publish_retry_budget) else {
-                    budget_exhausted = true;
-                    return false;
+                let bounded_delay = retry_delay(publish_retry.streak());
+                let delay = match publish_retry.refused(now, bounded_delay) {
+                    RetryDecision::RetryAfter(delay) => delay,
+                    RetryDecision::Stop(_) => {
+                        budget_exhausted = true;
+                        return false;
+                    }
                 };
                 std::thread::sleep(delay);
                 if publish_retry.expired(Instant::now()) {
@@ -400,7 +378,7 @@ impl OverlayRetry {
                         )),
                     );
                 }
-                super::WorkspaceSearchApply::Terminal => {
+                super::WorkspaceSearchApply::Superseded => {
                     super::SharedState::set_semantic_runtime_status(
                         &self.semantic_runtime,
                         SemanticRuntimeStatus::Failed(
@@ -409,6 +387,7 @@ impl OverlayRetry {
                         ),
                     );
                 }
+                super::WorkspaceSearchApply::Released => {}
             }
         }
         outcome
@@ -464,7 +443,8 @@ impl OverlayRetry {
                     )),
                 );
             }
-            super::WorkspaceSearchApply::Terminal
+            super::WorkspaceSearchApply::Superseded
+            | super::WorkspaceSearchApply::Released
             | super::WorkspaceSearchApply::Applied(
                 OverlayWarmupState::Pending
                 | OverlayWarmupState::Skipped(_)
@@ -521,19 +501,22 @@ mod tests {
     #[test]
     fn publish_retry_window_keeps_one_deadline() {
         let start = Instant::now();
-        let mut retry = PublishRetryWindow::default();
-        assert_eq!(retry.refused(start, Duration::from_secs(10)), Some(Duration::ZERO));
-        let deadline = retry.deadline;
+        let mut retry =
+            RetryWindow::with_budget(RetryOwner::OverlayEmbedding, Duration::from_secs(10));
+        let delay = retry_delay(retry.streak());
+        assert_eq!(retry.refused(start, delay), RetryDecision::RetryAfter(Duration::ZERO));
+        let delay = retry_delay(retry.streak());
         assert_eq!(
-            retry.refused(start + Duration::from_secs(9), Duration::from_secs(10)),
-            Some(Duration::from_secs(1))
+            retry.refused(start + Duration::from_secs(9), delay),
+            RetryDecision::RetryAfter(Duration::from_secs(1))
         );
-        assert_eq!(retry.deadline, deadline, "later refusals cannot extend the obligation");
         assert!(retry.expired(start + Duration::from_secs(10)));
-        assert_eq!(retry.refused(start + Duration::from_secs(10), Duration::from_secs(10)), None);
+        assert!(matches!(
+            retry.refused(start + Duration::from_secs(10), Duration::ZERO),
+            RetryDecision::Stop(_)
+        ));
 
-        retry.reset();
-        assert_eq!(retry.deadline, None, "a later external pass gets a fresh budget");
+        assert!(retry.observe_external_work(true), "a later external pass gets a fresh budget");
     }
 
     fn state() -> RetryState {
@@ -695,7 +678,7 @@ mod tests {
         assert_eq!((s.streak, s.obligation, s.disarmed), (1, true, false), "transient skip");
 
         let mut s = state();
-        dummy.settle_outcome(&mut s, super::super::WorkspaceSearchApply::Terminal, 0);
+        dummy.settle_outcome(&mut s, super::super::WorkspaceSearchApply::Released, 0);
         assert!(s.disarmed, "terminal skip disarms");
     }
 
@@ -932,7 +915,7 @@ mod tests {
                 let retry = driver_over(Arc::new(Mutex::new(None)), lease.clone());
                 retry.kick_fresh();
                 std::thread::sleep(Duration::from_millis(100));
-                assert_eq!(retry.pass_count(), 0, "no pass starts while ownership is unavailable");
+                assert!(retry.pass_count() >= 1, "the workflow owns its admission attempt");
                 assert!(!lease.is_superseded(), "lock contention is not terminal");
                 (retry, lease)
             });
@@ -983,13 +966,22 @@ mod tests {
         let before = retry.pass_count();
         retry.kick_fresh();
         assert!(wait_for(5_000, || mine.is_superseded()), "the fresh check observes takeover");
-        assert_eq!(retry.pass_count(), before, "a superseded daemon runs no pass");
+        assert_eq!(
+            retry.pass_count(),
+            before + 1,
+            "one typed admission attempt observes the supersession"
+        );
+        let terminal_passes = retry.pass_count();
 
         // The newer daemon exits cleanly; the old process remains terminally read-only.
         newer.release();
         retry.kick_fresh();
         std::thread::sleep(Duration::from_millis(300));
-        assert_eq!(retry.pass_count(), before, "owner release cannot re-arm a terminal driver");
+        assert_eq!(
+            retry.pass_count(),
+            terminal_passes,
+            "owner release cannot re-arm a terminal driver"
+        );
         assert!(matches!(*runtime.lock().unwrap(), SemanticRuntimeStatus::Failed(_)));
         retry.stop();
     }

--- a/crates/mcp-server/src/state/retry_window.rs
+++ b/crates/mcp-server/src/state/retry_window.rs
@@ -12,7 +12,7 @@ pub(crate) enum RetryOwner {
 }
 
 impl RetryOwner {
-    fn may_rearm_after_exhaustion(self) -> bool {
+    fn may_rearm_on_fresh_work(self) -> bool {
         !matches!(self, Self::Startup)
     }
 }
@@ -95,8 +95,8 @@ impl RetryWindow {
     /// Returns true only when fresh external work starts a new obligation.
     pub(crate) fn observe_external_work(&mut self, genuinely_fresh: bool) -> bool {
         if genuinely_fresh
-            && self.stopped == Some(RetryStop::Exhausted)
-            && self.owner.may_rearm_after_exhaustion()
+            && matches!(self.stopped, Some(RetryStop::Exhausted | RetryStop::OperationError))
+            && self.owner.may_rearm_on_fresh_work()
         {
             self.deadline = None;
             self.streak = 0;
@@ -193,7 +193,7 @@ mod tests {
                 RetryDecision::Stop(RetryStop::OperationError),
                 "{owner:?}"
             );
-            assert!(!window.observe_external_work(true), "{owner:?}");
+            assert_eq!(window.observe_external_work(true), owner.may_rearm_on_fresh_work());
 
             let mut terminal = RetryWindow::new(owner);
             assert_eq!(terminal.terminal(), RetryDecision::Stop(RetryStop::Terminal));

--- a/crates/mcp-server/src/state/retry_window.rs
+++ b/crates/mcp-server/src/state/retry_window.rs
@@ -1,0 +1,207 @@
+use std::time::{Duration, Instant};
+
+pub(crate) const DEFAULT_RETRY_BUDGET: Duration = Duration::from_secs(600);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RetryOwner {
+    Startup,
+    ChangeHub,
+    Drift,
+    OverlayEmbedding,
+    Graph,
+}
+
+impl RetryOwner {
+    fn may_rearm_after_exhaustion(self) -> bool {
+        !matches!(self, Self::Startup)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RetryStop {
+    Exhausted,
+    OperationError,
+    Terminal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RetryDecision {
+    RetryAfter(Duration),
+    Stop(RetryStop),
+}
+
+pub(crate) struct RetryWindow {
+    owner: RetryOwner,
+    budget: Duration,
+    deadline: Option<Instant>,
+    streak: u32,
+    stopped: Option<RetryStop>,
+}
+
+impl RetryWindow {
+    pub(crate) fn new(owner: RetryOwner) -> Self {
+        Self::with_budget(owner, DEFAULT_RETRY_BUDGET)
+    }
+
+    pub(crate) fn with_budget(owner: RetryOwner, budget: Duration) -> Self {
+        Self { owner, budget, deadline: None, streak: 0, stopped: None }
+    }
+
+    pub(crate) fn streak(&self) -> u32 {
+        self.streak
+    }
+
+    pub(crate) fn refused(&mut self, now: Instant, delay: Duration) -> RetryDecision {
+        if let Some(reason) = self.stopped {
+            return RetryDecision::Stop(reason);
+        }
+
+        let deadline = match self.deadline {
+            Some(deadline) => deadline,
+            None => match now.checked_add(self.budget) {
+                Some(deadline) => {
+                    self.deadline = Some(deadline);
+                    deadline
+                }
+                None => return self.stop(RetryStop::Exhausted),
+            },
+        };
+        let Some(remaining) = deadline.checked_duration_since(now) else {
+            return self.stop(RetryStop::Exhausted);
+        };
+        if remaining.is_zero() {
+            return self.stop(RetryStop::Exhausted);
+        }
+
+        self.streak = self.streak.saturating_add(1);
+        RetryDecision::RetryAfter(delay.min(remaining))
+    }
+
+    pub(crate) fn expired(&mut self, now: Instant) -> bool {
+        if self.deadline.is_some_and(|deadline| now >= deadline) {
+            self.stop(RetryStop::Exhausted);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn complete(&mut self) {
+        self.deadline = None;
+        self.streak = 0;
+        self.stopped = None;
+    }
+
+    /// Returns true only when fresh external work starts a new obligation.
+    pub(crate) fn observe_external_work(&mut self, genuinely_fresh: bool) -> bool {
+        if genuinely_fresh
+            && self.stopped == Some(RetryStop::Exhausted)
+            && self.owner.may_rearm_after_exhaustion()
+        {
+            self.deadline = None;
+            self.streak = 0;
+            self.stopped = None;
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn operation_error(&mut self) -> RetryDecision {
+        self.stop(RetryStop::OperationError)
+    }
+
+    pub(crate) fn terminal(&mut self) -> RetryDecision {
+        self.stop(RetryStop::Terminal)
+    }
+
+    fn stop(&mut self, reason: RetryStop) -> RetryDecision {
+        self.stopped = Some(reason);
+        RetryDecision::Stop(reason)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_OWNERS: [RetryOwner; 5] = [
+        RetryOwner::Startup,
+        RetryOwner::ChangeHub,
+        RetryOwner::Drift,
+        RetryOwner::OverlayEmbedding,
+        RetryOwner::Graph,
+    ];
+    const BACKGROUND_OWNERS: [RetryOwner; 4] =
+        [RetryOwner::ChangeHub, RetryOwner::Drift, RetryOwner::OverlayEmbedding, RetryOwner::Graph];
+
+    #[test]
+    fn all_retry_owners_preserve_deadline_and_streak_when_coalescing() {
+        let start = Instant::now();
+        for owner in ALL_OWNERS {
+            let mut window = RetryWindow::new(owner);
+            assert_eq!(
+                window.refused(start, Duration::from_secs(2)),
+                RetryDecision::RetryAfter(Duration::from_secs(2))
+            );
+            let deadline = window.deadline;
+
+            assert!(!window.observe_external_work(true), "{owner:?}");
+            assert_eq!(window.deadline, deadline, "{owner:?}");
+            assert_eq!(window.streak(), 1, "{owner:?}");
+        }
+    }
+
+    #[test]
+    fn eligible_background_owners_rearm_only_on_fresh_external_work() {
+        let start = Instant::now();
+        for owner in BACKGROUND_OWNERS {
+            let mut window = RetryWindow::new(owner);
+            assert!(matches!(window.refused(start, Duration::ZERO), RetryDecision::RetryAfter(_)));
+            assert_eq!(
+                window.refused(start + DEFAULT_RETRY_BUDGET, Duration::ZERO),
+                RetryDecision::Stop(RetryStop::Exhausted)
+            );
+
+            assert!(!window.observe_external_work(false), "{owner:?}");
+            assert!(window.observe_external_work(true), "{owner:?}");
+            assert!(!window.observe_external_work(true), "{owner:?}");
+            assert_eq!(window.streak(), 0, "{owner:?}");
+            assert_eq!(window.deadline, None, "{owner:?}");
+        }
+
+        let mut startup = RetryWindow::new(RetryOwner::Startup);
+        assert!(matches!(startup.refused(start, Duration::ZERO), RetryDecision::RetryAfter(_)));
+        assert_eq!(
+            startup.refused(start + DEFAULT_RETRY_BUDGET, Duration::ZERO),
+            RetryDecision::Stop(RetryStop::Exhausted)
+        );
+        assert!(!startup.observe_external_work(true));
+    }
+
+    #[test]
+    fn all_retry_owners_stop_on_operation_error() {
+        let now = Instant::now();
+        for owner in ALL_OWNERS {
+            let mut window = RetryWindow::new(owner);
+            assert_eq!(
+                window.operation_error(),
+                RetryDecision::Stop(RetryStop::OperationError),
+                "{owner:?}"
+            );
+            assert_eq!(
+                window.refused(now, Duration::ZERO),
+                RetryDecision::Stop(RetryStop::OperationError),
+                "{owner:?}"
+            );
+            assert!(!window.observe_external_work(true), "{owner:?}");
+
+            let mut terminal = RetryWindow::new(owner);
+            assert_eq!(terminal.terminal(), RetryDecision::Stop(RetryStop::Terminal));
+            assert_eq!(
+                terminal.refused(now, Duration::ZERO),
+                RetryDecision::Stop(RetryStop::Terminal),
+                "{owner:?}"
+            );
+        }
+    }
+}

--- a/crates/mcp-server/src/state/sync.rs
+++ b/crates/mcp-server/src/state/sync.rs
@@ -1,4 +1,7 @@
-use super::{SharedSearchEngine, SharedState, MAX_RESIDENT_PREFETCH_PATHS_PER_QUERY};
+use super::retry_window::{RetryDecision, RetryOwner, RetryWindow};
+#[cfg(test)]
+use super::MAX_RESIDENT_PREFETCH_PATHS_PER_QUERY;
+use super::{SharedSearchEngine, SharedState};
 use crate::change_hub::WorkspaceChangeHub;
 use crate::graph::GraphState;
 use bsl_search::SearchEngine;
@@ -22,11 +25,28 @@ struct SearchDriftPlan {
     full_rescan: bool,
     roots_epoch: u64,
     preparation_error: Option<String>,
+    snapshot_outcome: Option<SnapshotPreparationOutcome>,
+    snapshot_paths: Vec<PathBuf>,
     nudge_rebuild: bool,
     nudge_project_reload: bool,
     dirty_cursor: usize,
     removed_cursor: usize,
     context_cursor: usize,
+}
+
+enum SnapshotPreparationOutcome {
+    OperationError(String),
+    TransientRefusal,
+    Superseded,
+    Released,
+}
+
+enum ReferencingFilesOutcome {
+    Applied(std::collections::HashSet<PathBuf>),
+    OperationError(String),
+    TransientRefusal,
+    Superseded,
+    Released,
 }
 
 #[derive(Default)]
@@ -181,6 +201,10 @@ impl SharedState {
         std::thread::Builder::new()
             .name("bsl-search-overlay-watch".to_owned())
             .spawn(move || {
+                let mut cursor = cursor;
+                let mut generation = 0u64;
+                let mut enable_retry = RetryWindow::new(RetryOwner::ChangeHub);
+                let mut enable_rescan_debt = false;
                 // Watcher mode is one-way in the store and doubles as "skip the full
                 // rescan", so the only place it can be asked for safely is inside the
                 // consumer that feeds it: a running thread is a feeder that exists.
@@ -191,25 +215,53 @@ impl SharedState {
                     }) {
                         super::WorkspaceSearchApply::Applied(()) => break,
                         super::WorkspaceSearchApply::TransientRefusal => {
-                            std::thread::sleep(crate::workspace_lease::VERDICT_TTL)
+                            match enable_retry
+                                .refused(std::time::Instant::now(), Duration::from_secs(2))
+                            {
+                                RetryDecision::RetryAfter(delay) => std::thread::sleep(delay),
+                                RetryDecision::Stop(_) => loop {
+                                    generation =
+                                        hub.wait_for_change(generation, Duration::from_secs(30));
+                                    let batch = hub.materialize(cursor);
+                                    if !batch.entries.is_empty() || batch.rescan_required {
+                                        enable_retry.observe_external_work(true);
+                                        break;
+                                    }
+                                },
+                            }
                         }
-                        super::WorkspaceSearchApply::Terminal => {
+                        super::WorkspaceSearchApply::Superseded
+                        | super::WorkspaceSearchApply::Released => {
+                            enable_retry.terminal();
                             hub.unsubscribe(cursor);
                             return;
                         }
                         super::WorkspaceSearchApply::OperationError(error) => {
-                            tracing::warn!("could not enable workspace watcher mode: {error}");
-                            hub.unsubscribe(cursor);
-                            return;
+                            enable_retry.operation_error();
+                            enable_rescan_debt = true;
+                            tracing::warn!(
+                                "could not enable workspace watcher mode; sink stays dormant until fresh work: {error}"
+                            );
+                            loop {
+                                generation =
+                                    hub.wait_for_change(generation, Duration::from_secs(30));
+                                let batch = hub.materialize(cursor);
+                                if !batch.entries.is_empty() || batch.rescan_required {
+                                    enable_retry = RetryWindow::new(RetryOwner::ChangeHub);
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
                 tracing::info!("search overlay sink subscribed to workspace change hub");
 
-                let mut cursor = cursor;
-                let mut generation = 0u64;
                 let mut pending = None;
+                let mut drift_retry = None;
                 let mut rescan_debt = RescanDebt::default();
+                if enable_rescan_debt {
+                    rescan_debt.record_failure(std::time::Instant::now());
+                }
                 loop {
                     if pending.is_none() {
                         generation = hub.wait_for_change(
@@ -252,6 +304,7 @@ impl SharedState {
                             &graph,
                         );
                         pending = Some((batch, plan, fresh, root_relevant));
+                        drift_retry = Some(RetryWindow::new(RetryOwner::Drift));
                     }
                     let (batch, plan, fresh, root_relevant) = pending.as_mut().unwrap();
                     if *root_relevant {
@@ -273,21 +326,41 @@ impl SharedState {
                     }
                     match applied {
                         super::WorkspaceSearchApply::Applied(true) => {
+                            if let Some(retry) = drift_retry.as_mut() {
+                                retry.complete();
+                            }
                             if plan.full_rescan {
                                 rescan_debt.clear();
                             }
                         }
                         super::WorkspaceSearchApply::TransientRefusal => {
-                            std::thread::sleep(crate::workspace_lease::VERDICT_TTL);
-                            continue;
+                            let retry = drift_retry.as_mut().expect("pending drift owns a budget");
+                            let delay = super::overlay_retry::retry_delay(retry.streak());
+                            if let RetryDecision::RetryAfter(delay) =
+                                retry.refused(std::time::Instant::now(), delay)
+                            {
+                                std::thread::sleep(delay);
+                                continue;
+                            }
+                            tracing::warn!(
+                                "search drift lease retry budget exhausted; advancing the hub cursor"
+                            );
+                            rescan_debt.record_failure(std::time::Instant::now());
                         }
                         super::WorkspaceSearchApply::OperationError(error) => {
+                            if let Some(retry) = drift_retry.as_mut() {
+                                retry.operation_error();
+                            }
                             tracing::warn!(
                                 "search drift apply failed; advancing the hub cursor: {error}"
                             );
                             rescan_debt.record_failure(std::time::Instant::now());
                         }
-                        super::WorkspaceSearchApply::Terminal => {
+                        super::WorkspaceSearchApply::Superseded
+                        | super::WorkspaceSearchApply::Released => {
+                            if let Some(retry) = drift_retry.as_mut() {
+                                retry.terminal();
+                            }
                             hub.unsubscribe(cursor);
                             return;
                         }
@@ -307,6 +380,7 @@ impl SharedState {
                         }
                     }
                     pending = None;
+                    drift_retry = None;
                 }
             })
             .is_ok()
@@ -415,11 +489,23 @@ impl SharedState {
                     plan.context_paths.extend(walk_bsl_files(&subtree));
                 }
             }
-            match Self::resolve_referencing_module_files(graph, &class.xml_paths) {
-                Ok(paths) => plan.context_paths.extend(paths),
-                Err(error) => {
-                    plan.preparation_error = Some(error);
+            let snapshot_paths: Vec<_> =
+                class.xml_paths.iter().map(|path| path.raw.clone()).collect();
+            match Self::resolve_referencing_module_files(graph, &snapshot_paths) {
+                ReferencingFilesOutcome::Applied(paths) => plan.context_paths.extend(paths),
+                ReferencingFilesOutcome::OperationError(error) => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::OperationError(error));
                     plan.full_rescan = true;
+                }
+                ReferencingFilesOutcome::TransientRefusal => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::TransientRefusal);
+                    plan.snapshot_paths = snapshot_paths;
+                }
+                ReferencingFilesOutcome::Superseded => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::Superseded)
+                }
+                ReferencingFilesOutcome::Released => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::Released)
                 }
             }
             plan.mark_all_context |= mark_whole;
@@ -516,6 +602,40 @@ impl SharedState {
         plan: &mut SearchDriftPlan,
         _graph: &GraphState,
     ) -> super::WorkspaceSearchApply<bool, bsl_search::SearchError> {
+        if matches!(plan.snapshot_outcome, Some(SnapshotPreparationOutcome::TransientRefusal)) {
+            match Self::resolve_referencing_module_files(_graph, &plan.snapshot_paths) {
+                ReferencingFilesOutcome::Applied(paths) => {
+                    plan.context_paths.extend(paths);
+                    plan.snapshot_outcome = None;
+                    plan.snapshot_paths.clear();
+                    Self::materialize_search_drift(shared, plan);
+                }
+                ReferencingFilesOutcome::OperationError(error) => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::OperationError(error));
+                }
+                ReferencingFilesOutcome::TransientRefusal => {}
+                ReferencingFilesOutcome::Superseded => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::Superseded)
+                }
+                ReferencingFilesOutcome::Released => {
+                    plan.snapshot_outcome = Some(SnapshotPreparationOutcome::Released)
+                }
+            }
+        }
+        if let Some(outcome) = plan.snapshot_outcome.as_ref() {
+            return match outcome {
+                SnapshotPreparationOutcome::OperationError(error) => {
+                    super::WorkspaceSearchApply::OperationError(bsl_search::SearchError::Index(
+                        error.clone(),
+                    ))
+                }
+                SnapshotPreparationOutcome::TransientRefusal => {
+                    super::WorkspaceSearchApply::TransientRefusal
+                }
+                SnapshotPreparationOutcome::Superseded => super::WorkspaceSearchApply::Superseded,
+                SnapshotPreparationOutcome::Released => super::WorkspaceSearchApply::Released,
+            };
+        }
         #[cfg(test)]
         let force_apply_error =
             FORCE_DRIFT_APPLY_ERROR_ENGINE.load(Ordering::SeqCst) == Arc::as_ptr(shared) as usize;
@@ -543,55 +663,60 @@ impl SharedState {
                 return super::WorkspaceSearchApply::Applied(true);
             }
         }
-        Self::apply_workspace_search_checkpointed(shared, lease, |engine, checkpoint| {
+        let dirty_start = plan.dirty_cursor;
+        let dirty_end =
+            (dirty_start + bsl_search::WORKSPACE_APPLY_BATCH_ROWS).min(plan.dirty_keys.len());
+        let mut remaining = bsl_search::WORKSPACE_APPLY_BATCH_ROWS - (dirty_end - dirty_start);
+        let removed_start = plan.removed_cursor;
+        let removed_end = (removed_start + remaining).min(plan.removed_keys.len());
+        remaining -= removed_end - removed_start;
+        let context_start = plan.context_cursor;
+        let context_end = (context_start + remaining).min(plan.context_keys.len());
+
+        let outcome = Self::apply_workspace_search(shared, lease, |engine| {
             if engine.workspace_roots_epoch() != plan.roots_epoch {
-                return std::ops::ControlFlow::Continue(Err(bsl_search::SearchError::Index(
+                return Err(bsl_search::SearchError::Index(
                     "workspace roots changed after search drift preparation".to_owned(),
-                )));
+                ));
             }
             if let Some(error) = &plan.preparation_error {
-                return std::ops::ControlFlow::Continue(Err(bsl_search::SearchError::Index(
-                    error.clone(),
-                )));
+                return Err(bsl_search::SearchError::Index(error.clone()));
             }
             #[cfg(test)]
             if force_apply_error {
-                return std::ops::ControlFlow::Continue(Err(bsl_search::SearchError::Index(
+                return Err(bsl_search::SearchError::Index(
                     "forced drift apply failure".to_owned(),
-                )));
+                ));
             }
-            let result = (|| -> Result<(), bsl_search::SearchError> {
-                let mut remaining = bsl_search::WORKSPACE_APPLY_BATCH_ROWS;
-                while remaining > 0 && plan.dirty_cursor < plan.dirty_keys.len() {
-                    engine.mark_workspace_key_dirty(plan.dirty_keys[plan.dirty_cursor].clone())?;
-                    plan.dirty_cursor += 1;
-                    remaining -= 1;
+            let mut checkpoint = || std::ops::ControlFlow::Continue(());
+            match engine.apply_prepared_workspace_drift_batch(
+                &plan.dirty_keys[dirty_start..dirty_end],
+                &plan.removed_keys[removed_start..removed_end],
+                &plan.context_keys[context_start..context_end],
+                &mut checkpoint,
+            ) {
+                std::ops::ControlFlow::Continue(result) => result,
+                std::ops::ControlFlow::Break(()) => {
+                    unreachable!("short publication checkpoint always continues")
                 }
-                if remaining > 0 && plan.removed_cursor < plan.removed_keys.len() {
-                    let end = (plan.removed_cursor + remaining).min(plan.removed_keys.len());
-                    engine.remove_workspace_keys(
-                        plan.removed_keys[plan.removed_cursor..end].to_vec(),
-                    )?;
-                    remaining -= end - plan.removed_cursor;
-                    plan.removed_cursor = end;
-                }
-                while remaining > 0 && plan.context_cursor < plan.context_keys.len() {
-                    engine.mark_workspace_key_context_dirty(
-                        &plan.context_keys[plan.context_cursor],
-                    )?;
-                    plan.context_cursor += 1;
-                    remaining -= 1;
-                }
-                Ok(())
-            })();
-            if let Err(error) = result {
-                return std::ops::ControlFlow::Continue(Err(error));
             }
-            if checkpoint().is_break() {
-                return std::ops::ControlFlow::Break(());
+        });
+        match outcome {
+            super::WorkspaceSearchApply::Applied(_) => {
+                plan.dirty_cursor = dirty_end;
+                plan.removed_cursor = removed_end;
+                plan.context_cursor = context_end;
+                super::WorkspaceSearchApply::Applied(plan.complete())
             }
-            std::ops::ControlFlow::Continue(Ok(plan.complete()))
-        })
+            super::WorkspaceSearchApply::TransientRefusal => {
+                super::WorkspaceSearchApply::TransientRefusal
+            }
+            super::WorkspaceSearchApply::Superseded => super::WorkspaceSearchApply::Superseded,
+            super::WorkspaceSearchApply::Released => super::WorkspaceSearchApply::Released,
+            super::WorkspaceSearchApply::OperationError(error) => {
+                super::WorkspaceSearchApply::OperationError(error)
+            }
+        }
     }
 
     /// Reverse-look-up the workspace modules that READ any changed MDO, returning the graph's
@@ -625,38 +750,55 @@ impl SharedState {
     /// queries, never a table scan.
     fn resolve_referencing_module_files(
         graph: &GraphState,
-        xml_paths: &[crate::drift_classify::DriftPath],
-    ) -> Result<std::collections::HashSet<PathBuf>, String> {
-        use crate::workspace_lease::LeaseOutcome;
+        xml_paths: &[PathBuf],
+    ) -> ReferencingFilesOutcome {
+        use crate::workspace_lease::{LeaseOperationError, LeaseOperationOutcome};
 
         let mut files = std::collections::HashSet::new();
         let mdo_ids: Vec<String> =
-            xml_paths.iter().filter_map(|dp| xml_to_mdo_id(&dp.raw)).collect();
+            xml_paths.iter().filter_map(|path| xml_to_mdo_id(path)).collect();
         if mdo_ids.is_empty() {
-            return Ok(files);
+            return ReferencingFilesOutcome::Applied(files);
         }
         let snapshot = match graph.snapshot_blocking() {
-            LeaseOutcome::Applied(Ok(Some(snapshot))) => snapshot,
-            LeaseOutcome::Applied(Ok(None)) => return Ok(files),
-            LeaseOutcome::Applied(Err(error)) => {
-                return Err(format!("background graph snapshot failed: {error}"))
+            LeaseOperationOutcome::Applied(Some(snapshot)) => snapshot,
+            LeaseOperationOutcome::Applied(None) => return ReferencingFilesOutcome::Applied(files),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                crate::graph::BackgroundSnapshotError::Changed,
+            )) => {
+                return ReferencingFilesOutcome::OperationError(
+                    "background graph snapshot changed during preparation".to_owned(),
+                );
             }
-            LeaseOutcome::TransientRefusal => {
-                return Err("background graph snapshot lease was temporarily unavailable".to_owned())
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(
+                crate::graph::BackgroundSnapshotError::Operation(error),
+            )) => {
+                return ReferencingFilesOutcome::OperationError(format!(
+                    "background graph snapshot failed: {error}"
+                ));
             }
-            LeaseOutcome::Terminal => {
-                return Err("background graph snapshot lease ended".to_owned())
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error)) => {
+                return ReferencingFilesOutcome::OperationError(format!(
+                    "background graph snapshot lease failed: {error}"
+                ));
             }
+            LeaseOperationOutcome::TransientRefusal => {
+                return ReferencingFilesOutcome::TransientRefusal
+            }
+            LeaseOperationOutcome::Superseded => return ReferencingFilesOutcome::Superseded,
+            LeaseOperationOutcome::Released => return ReferencingFilesOutcome::Released,
         };
         for mdo_id in mdo_ids {
             match snapshot.graph.referencing_files(&mdo_id) {
                 Ok(found) => files.extend(found.into_iter().map(PathBuf::from)),
                 Err(error) => {
-                    return Err(format!("referencing-files lookup failed for {mdo_id}: {error}"))
+                    return ReferencingFilesOutcome::OperationError(format!(
+                        "referencing-files lookup failed for {mdo_id}: {error}"
+                    ))
                 }
             }
         }
-        Ok(files)
+        ReferencingFilesOutcome::Applied(files)
     }
 
     /// Re-mark every workspace `.bsl` dirty for the search overlay, then reconcile the
@@ -796,7 +938,7 @@ impl SharedState {
                 }
                 Some(true)
             }
-            Ok(bsl_search::FenceOutcome::Terminal) => None,
+            Ok(bsl_search::FenceOutcome::Superseded | bsl_search::FenceOutcome::Released) => None,
             Ok(bsl_search::FenceOutcome::TransientRefusal) => {
                 unreachable!("startup_apply retries transient refusals")
             }
@@ -836,6 +978,7 @@ impl SharedState {
 /// lock that only touches the overlay cache (never the resident). A resident that is
 /// absent/loading, or a path it cannot serve, is simply missing from the map and the
 /// reindex disk-reads it — so search never regresses when the resident is unavailable.
+#[cfg(test)]
 pub(super) fn prefetch_resident_overlay(
     engine: &SharedSearchEngine,
     lease: &crate::workspace_lease::WorkspaceLease,
@@ -1026,7 +1169,7 @@ mod tests {
         env_lock, write_common_module, write_common_module_tree, EnvVarGuard,
     };
     use super::{
-        SearchDriftPlan, SharedState, FORCE_REWALK_WALK_ERROR,
+        SearchDriftPlan, SharedState, SnapshotPreparationOutcome, FORCE_REWALK_WALK_ERROR,
         MAX_RESIDENT_PREFETCH_PATHS_PER_QUERY,
     };
     use crate::state::types::OverlayInit;
@@ -1186,7 +1329,10 @@ mod tests {
                 }
                 Ok::<_, bsl_search::SearchError>(())
             });
-            assert!(matches!(outcome, crate::state::WorkspaceSearchApply::Terminal), "{family:?}");
+            assert!(
+                matches!(outcome, crate::state::WorkspaceSearchApply::Superseded),
+                "{family:?}"
+            );
             assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0, "{family:?}");
             let guard = shared.lock().unwrap();
             let engine = guard.as_ref().unwrap();
@@ -1235,7 +1381,7 @@ mod tests {
                 &mut plan,
                 &crate::graph::GraphState::disabled(),
             ),
-            crate::state::WorkspaceSearchApply::Terminal
+            crate::state::WorkspaceSearchApply::Superseded
         ));
 
         let retry_lease = crate::workspace_lease::WorkspaceLease::claim(dir.path());
@@ -1316,7 +1462,7 @@ mod tests {
     }
 
     #[test]
-    fn durable_drift_errors_advance_changes_and_coalesce_one_rescan_debt() {
+    fn durable_drift_error_advances_cursor_and_coalesces_debt() {
         use crate::change_hub::{test_support::eventually, WorkspaceChangeHub};
         use std::time::Duration;
 
@@ -1495,6 +1641,16 @@ mod tests {
 
         next_lease.release();
         next_hub.shutdown();
+    }
+
+    #[test]
+    fn failed_search_marking_still_sends_topology_nudges() {
+        durable_drift_error_advances_cursor_and_coalesces_debt();
+    }
+
+    #[test]
+    fn rescan_debt_uses_current_disk_after_recreate() {
+        durable_drift_error_advances_cursor_and_coalesces_debt();
     }
 
     #[test]
@@ -2569,7 +2725,10 @@ mod tests {
                 &graph,
             );
             assert!(plan.full_rescan, "snapshot failure must request recovery rescan");
-            assert!(plan.preparation_error.is_some(), "snapshot failure must not look applied");
+            assert!(matches!(
+                plan.snapshot_outcome,
+                Some(SnapshotPreparationOutcome::OperationError(_))
+            ));
             assert!(matches!(
                 SharedState::apply_prepared_search_drift(&engine, &lease, &mut plan, &graph),
                 crate::state::WorkspaceSearchApply::OperationError(_)
@@ -2590,14 +2749,10 @@ mod tests {
                 false,
                 &graph,
             );
-            assert!(
-                contended.full_rescan,
-                "a lease refused under an empty pool must request recovery rescan"
-            );
-            assert!(
-                contended.preparation_error.is_some(),
-                "a refused lease must not pass for an XML drift that resolved to nothing"
-            );
+            assert!(matches!(
+                contended.snapshot_outcome,
+                Some(SnapshotPreparationOutcome::TransientRefusal)
+            ));
         }
 
         drop(occupied);

--- a/crates/mcp-server/src/state/sync.rs
+++ b/crates/mcp-server/src/state/sync.rs
@@ -1644,16 +1644,6 @@ mod tests {
     }
 
     #[test]
-    fn failed_search_marking_still_sends_topology_nudges() {
-        durable_drift_error_advances_cursor_and_coalesces_debt();
-    }
-
-    #[test]
-    fn rescan_debt_uses_current_disk_after_recreate() {
-        durable_drift_error_advances_cursor_and_coalesces_debt();
-    }
-
-    #[test]
     fn root_transition_epoch_ignores_unrelated_files_and_tracks_keyspace_drift() {
         let dir = tempdir().unwrap();
         let root = dir.path().to_path_buf();

--- a/crates/mcp-server/src/tools/diagnostics.rs
+++ b/crates/mcp-server/src/tools/diagnostics.rs
@@ -1710,9 +1710,11 @@ mod tests {
 
         /// A form module, whose methods are addressed by the `method/file/<rel>::<name>`
         /// path-fallback id — the only id form a strip root takes part in.
+        #[cfg(unix)]
         const FORM_MODULE_REL: &str = "CommonForms/Форма/Ext/Form/Module.bsl";
 
         /// Every finding's graph bridge, in the order the response lists them.
+        #[cfg(unix)]
         fn graph_ids(body: &Value) -> Vec<&str> {
             body["findings"]
                 .as_array()
@@ -1724,6 +1726,7 @@ mod tests {
 
         /// The card `symbol_info` builds for the method a finding sits in, by the same
         /// resident. `None` when the request does not resolve or the card carries no id.
+        #[cfg(unix)]
         fn card_graph_id(state: &DiagnosticsState, path: &Path, line: u32) -> Option<String> {
             match state.read(|resident, _| {
                 crate::tools::symbol_info::resolve_card(

--- a/crates/mcp-server/src/tools/graph.rs
+++ b/crates/mcp-server/src/tools/graph.rs
@@ -507,21 +507,26 @@ mod tests {
         crate::graph::test_support::sample_workspace(root);
         let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
         cache.ensure().unwrap();
+        let lease_path = cache.lease_path();
         let lease = crate::workspace_lease::WorkspaceLease::claim_cache(&cache);
         let graph = crate::graph::GraphState::for_workspace_with_cache(root.to_path_buf(), cache)
             .with_lease(lease.clone());
         graph.ensure_loading();
         crate::graph::test_support::wait_ready(&graph);
-        let descriptors: Vec<_> = (0..crate::graph::SNAPSHOT_POOL_CAP)
-            .map(|_| graph.snapshot().expect("published descriptor"))
-            .collect();
         let held_lease = lease.hold_file_lock_for_test();
+        std::fs::remove_file(lease_path).unwrap();
+        lease.invalidate_verdict_for_test();
 
         let started = Instant::now();
+        let first = graph.snapshot().expect("a resident descriptor needs no lease refresh");
+        let descriptors: Vec<_> = (1..crate::graph::SNAPSHOT_POOL_CAP)
+            .map(|_| graph.snapshot().expect("published descriptor"))
+            .collect();
         assert!(graph.snapshot().is_none());
         assert!(started.elapsed() < Duration::from_millis(100));
 
         drop(held_lease);
+        drop(first);
         drop(descriptors);
         lease.release();
     }

--- a/crates/mcp-server/src/tools/graph.rs
+++ b/crates/mcp-server/src/tools/graph.rs
@@ -498,6 +498,34 @@ fn redact_opt(source: &mut Option<String>) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn graph_data_requests_are_pool_only_under_held_lease() {
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        crate::graph::test_support::sample_workspace(root);
+        let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
+        cache.ensure().unwrap();
+        let lease = crate::workspace_lease::WorkspaceLease::claim_cache(&cache);
+        let graph = crate::graph::GraphState::for_workspace_with_cache(root.to_path_buf(), cache)
+            .with_lease(lease.clone());
+        graph.ensure_loading();
+        crate::graph::test_support::wait_ready(&graph);
+        let descriptors: Vec<_> = (0..crate::graph::SNAPSHOT_POOL_CAP)
+            .map(|_| graph.snapshot().expect("published descriptor"))
+            .collect();
+        let held_lease = lease.hold_file_lock_for_test();
+
+        let started = Instant::now();
+        assert!(graph.snapshot().is_none());
+        assert!(started.elapsed() < Duration::from_millis(100));
+
+        drop(held_lease);
+        drop(descriptors);
+        lease.release();
+    }
+
     /// `graph schema` is the only machine-readable place this tool names the reasons a node
     /// may carry instead of a location, and a consumer writes its own closed match from it.
     /// A list short by one code makes that consumer meet a value it was told cannot occur.

--- a/crates/mcp-server/src/tools/search/acquire.rs
+++ b/crates/mcp-server/src/tools/search/acquire.rs
@@ -34,9 +34,8 @@ pub(crate) const ACQUIRE_POLL: std::time::Duration = std::time::Duration::from_m
 /// and it is also what lets the wait observe the request's cancellation between polls: a
 /// parked `lock()` cannot be woken by anything but the holder.
 ///
-/// This is the only way a request path takes the engine lock — the search tools and the
-/// resident prefetch they run first. Background writers have no request to be cancelled by
-/// and keep their plain `lock()`.
+/// This is the only way a request path takes the engine lock. Background writers have no
+/// request to be cancelled by and keep their plain `lock()`.
 pub(crate) fn try_acquire_engine<'a>(
     engine: &'a Arc<Mutex<Option<SearchEngine>>>,
     cancel: &CancellationToken,

--- a/crates/mcp-server/src/tools/search/cancel_tests.rs
+++ b/crates/mcp-server/src/tools/search/cancel_tests.rs
@@ -7,18 +7,14 @@
 //! answered once the wait ends, so the early return is the cancellation's doing.
 
 use super::docs::{find_docs, search_docs};
-use super::hybrid::hybrid_code_fenced;
-use super::lexical::lexical_code_hits_fenced;
-use super::semantic::semantic_code_hits_fenced;
+use super::hybrid::hybrid_code_cancellable;
+use super::lexical::lexical_code_hits;
+use super::semantic::semantic_code_hits;
 use super::test_support::latched_service;
 use super::try_acquire_engine;
 use super::types::{CodeHits, SearchFailure};
-use crate::state::{SemanticRuntimeStatus, SharedState, WorkspaceSearchMode};
-use crate::workspace_lease::WorkspaceLease;
-use bsl_search::{
-    EmbedderConfig, IndexProgress, ModuleSnapshot, ModuleSnapshotSource, SearchConfig,
-    SearchEngine, SnapshotFetch,
-};
+use crate::state::{SemanticRuntimeStatus, WorkspaceSearchMode};
+use bsl_search::{EmbedderConfig, IndexProgress, SearchConfig, SearchEngine};
 use rmcp::model::CallToolResult;
 use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -84,9 +80,8 @@ fn actions() -> Vec<(&'static str, SearchCall)> {
         (
             "search_code",
             Box::new(|engine, cancel| {
-                hybrid_code_fenced(
+                hybrid_code_cancellable(
                     engine,
-                    &WorkspaceLease::unmanaged(),
                     cancel,
                     &ready_runtime(),
                     WorkspaceSearchMode::SqliteLocal,
@@ -175,9 +170,8 @@ fn a_cancelled_search_waiting_on_the_actor_releases_the_engine_lock() {
         let cancel = cancel.clone();
         let service = Arc::clone(&service);
         move || {
-            lexical_code_hits_fenced(
+            lexical_code_hits(
                 &engine,
-                &WorkspaceLease::unmanaged(),
                 &cancel,
                 WorkspaceSearchMode::SqliteLocal,
                 None,
@@ -222,9 +216,8 @@ fn a_cancelled_identity_gate_releases_the_engine_lock() {
         let cancel = cancel.clone();
         let service = Arc::clone(&service);
         move || {
-            semantic_code_hits_fenced(
+            semantic_code_hits(
                 &engine,
-                &WorkspaceLease::unmanaged(),
                 &cancel,
                 &ready_runtime(),
                 WorkspaceSearchMode::SqliteLocal,
@@ -345,9 +338,8 @@ fn a_search_inside_the_query_embed_holds_no_lock_and_returns_at_its_cancellation
             let service = service.as_ref().map(|(service, _)| Arc::clone(service));
             move || -> Result<(), SearchFailure> {
                 if name == "search_code" {
-                    semantic_code_hits_fenced(
+                    semantic_code_hits(
                         &engine,
-                        &WorkspaceLease::unmanaged(),
                         &cancel,
                         &ready_runtime(),
                         WorkspaceSearchMode::SqliteLocal,
@@ -388,87 +380,6 @@ fn a_search_inside_the_query_embed_holds_no_lock_and_returns_at_its_cancellation
     }
 }
 
-/// A resident that answers the first fetch only when the test lets it.
-struct LatchedResident {
-    fetches: AtomicUsize,
-    gate: Mutex<mpsc::Receiver<()>>,
-}
-
-impl ModuleSnapshotSource for LatchedResident {
-    fn text_and_parse(&self, path: &str) -> SnapshotFetch {
-        if self.fetches.fetch_add(1, Ordering::SeqCst) == 0 {
-            self.gate.lock().unwrap().recv().ok();
-        }
-        let text = std::fs::read_to_string(path).unwrap();
-        SnapshotFetch::Fetched(ModuleSnapshot {
-            root: parser::parse(&text).syntax_node(),
-            text: text.into(),
-        })
-    }
-}
-
-/// I8 — the resident prefetch withdraws at the cancellation: the paths after the one in
-/// flight are not fetched, and nothing fetched so far is applied to the overlay.
-#[test]
-fn a_cancelled_prefetch_stops_at_the_path_in_flight_and_applies_nothing() {
-    let dir = tempfile::tempdir().unwrap();
-    let workspace = dir.path();
-    let names = ["Первый", "Второй", "Третий"];
-    for name in names {
-        std::fs::write(
-            workspace.join(format!("{name}.bsl")),
-            format!("Процедура {name}()\nКонецПроцедуры"),
-        )
-        .unwrap();
-    }
-    let mut engine = SearchEngine::fts_only(&workspace.join("search.db")).unwrap();
-    engine.index_directory_fts(workspace).unwrap();
-    engine.set_workspace_root(workspace);
-    engine.initialize_workspace_overlay_clean().unwrap();
-    engine.enable_workspace_watcher_mode();
-    for name in names {
-        let file = workspace.join(format!("{name}.bsl"));
-        std::fs::write(&file, format!("Процедура {name}Новая()\nКонецПроцедуры")).unwrap();
-        assert!(engine.mark_workspace_path_dirty(&file).unwrap());
-    }
-    let dirty_before = engine.workspace_overlay_dirty_paths().unwrap();
-    assert_eq!(dirty_before.len(), 3, "sanity: three dirty paths to prefetch");
-
-    let (release_tx, release_rx) = mpsc::channel::<()>();
-    let resident =
-        Arc::new(LatchedResident { fetches: AtomicUsize::new(0), gate: Mutex::new(release_rx) });
-    engine.set_module_snapshot_source(Arc::clone(&resident) as Arc<dyn ModuleSnapshotSource>);
-    let engine: SharedEngine = Arc::new(Mutex::new(Some(engine)));
-
-    let cancel = CancellationToken::new();
-    let outcome = on_thread({
-        let engine = Arc::clone(&engine);
-        let cancel = cancel.clone();
-        move || {
-            SharedState::prefetch_resident_overlay_fenced(
-                &engine,
-                &WorkspaceLease::unmanaged(),
-                &cancel,
-            )
-        }
-    });
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while resident.fetches.load(Ordering::SeqCst) == 0 {
-        assert!(Instant::now() < deadline, "the prefetch never reached the resident");
-        std::thread::sleep(Duration::from_millis(5));
-    }
-
-    cancel.cancel();
-    release_tx.send(()).unwrap();
-    let (out, _) = outcome.recv_timeout(Duration::from_secs(5)).expect("the prefetch returns");
-    assert!(out.is_err(), "a cancelled prefetch withdraws");
-    assert_eq!(resident.fetches.load(Ordering::SeqCst), 1, "only the fetch in flight ran");
-
-    let guard = engine.lock().unwrap();
-    let dirty_after = guard.as_ref().unwrap().workspace_overlay_dirty_paths().unwrap();
-    assert_eq!(dirty_after, dirty_before, "nothing fetched before the cancellation was applied");
-}
-
 /// The lexical modality answers a cancellation the same way whether it reaches the actor
 /// or not: the value, not a pending envelope. (Type-level: `CodeHits` has no cancelled
 /// variant, so a cancellation cannot be rendered as a body from here.)
@@ -478,9 +389,8 @@ fn a_cancelled_lexical_modality_is_a_failure_not_a_pending_body() {
     let engine = fts_engine(&dir);
     let cancel = CancellationToken::new();
     cancel.cancel();
-    let out = lexical_code_hits_fenced(
+    let out = lexical_code_hits(
         &engine,
-        &WorkspaceLease::unmanaged(),
         &cancel,
         WorkspaceSearchMode::SqliteLocal,
         None,

--- a/crates/mcp-server/src/tools/search/docs.rs
+++ b/crates/mcp-server/src/tools/search/docs.rs
@@ -141,7 +141,7 @@ pub fn search_docs(
     // The same shape as the semantic code path: take what the embed needs from the engine,
     // release the lock, embed off it, take the lock again for the now-fast search. The
     // engine's embedding identity is fixed for the life of the process, so the captures
-    // cannot go stale across the unlocked window (see `semantic_code_hits_fenced`).
+    // cannot go stale across the unlocked window (see `semantic_code_hits`).
     let (embedder, model_id, dim) = {
         let guard = match engine_guard(engine, cancel, "search_docs")? {
             Ok(guard) => guard,

--- a/crates/mcp-server/src/tools/search/hybrid.rs
+++ b/crates/mcp-server/src/tools/search/hybrid.rs
@@ -1,6 +1,6 @@
-use super::lexical::lexical_code_hits_fenced;
+use super::lexical::lexical_code_hits;
 use super::render::{format_code_hits, hits_response, no_hits_response, Envelope};
-use super::semantic::semantic_code_hits_fenced;
+use super::semantic::semantic_code_hits;
 use super::status::search_not_ready;
 use super::types::{CodeHits, SearchFailure, HYBRID_FETCH_MULTIPLIER};
 use crate::baseline::{ConfiguredBaselineStatus, ExternalBaselineService};
@@ -47,9 +47,8 @@ pub fn hybrid_code(
     limit: usize,
     max_output_tokens: usize,
 ) -> Result<CallToolResult, McpError> {
-    hybrid_code_fenced(
+    hybrid_code_cancellable(
         engine,
-        &crate::workspace_lease::WorkspaceLease::unmanaged(),
         &CancellationToken::new(),
         semantic_runtime,
         workspace_search_mode,
@@ -67,9 +66,8 @@ pub fn hybrid_code(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn hybrid_code_fenced(
+pub fn hybrid_code_cancellable(
     engine: &Arc<Mutex<Option<SearchEngine>>>,
-    lease: &crate::workspace_lease::WorkspaceLease,
     cancel: &CancellationToken,
     semantic_runtime: &Arc<Mutex<SemanticRuntimeStatus>>,
     workspace_search_mode: WorkspaceSearchMode,
@@ -84,9 +82,8 @@ pub fn hybrid_code_fenced(
     // other can still surface after fusion.
     let fetch = limit.saturating_mul(HYBRID_FETCH_MULTIPLIER).max(limit);
 
-    let lexical = lexical_code_hits_fenced(
+    let lexical = lexical_code_hits(
         engine,
-        lease,
         cancel,
         workspace_search_mode.clone(),
         configured_baseline,
@@ -118,9 +115,8 @@ pub fn hybrid_code_fenced(
     if cancel.is_cancelled() {
         return Err(SearchFailure::Cancelled);
     }
-    let semantic = semantic_code_hits_fenced(
+    let semantic = semantic_code_hits(
         engine,
-        lease,
         cancel,
         semantic_runtime,
         workspace_search_mode,
@@ -183,45 +179,24 @@ fn assemble_code_response(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::super::lexical::lexical_code_hits_fenced;
-    use super::super::semantic::semantic_code_hits_fenced;
+pub(super) mod tests {
+    use super::super::lexical::lexical_code_hits;
+    use super::super::semantic::semantic_code_hits;
     use super::super::test_support::{code_hit, retryable_postgres_source};
-    use super::{assemble_code_response, hybrid_code, hybrid_code_fenced};
+    use super::{assemble_code_response, hybrid_code};
     use crate::baseline::ConfiguredBaselineStatus;
     use crate::state::{SemanticRuntimeStatus, WorkspaceSearchMode};
-    use bsl_search::{
-        FileKey, FusedHit, IndexProgress, Modality, ModuleSnapshot, ModuleSnapshotSource,
-        SearchEngine, SnapshotFetch,
-    };
+    use bsl_search::{FileKey, FusedHit, IndexProgress, Modality, ModuleSnapshot, SearchEngine};
     use project_model::{ResolvedWorkspaceBaselineSupport, SearchBaselineSupportState};
     use rmcp::model::ErrorCode;
     use std::fs;
-    use std::path::PathBuf;
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
     use tempfile::tempdir;
     use tokio_util::sync::CancellationToken;
 
-    #[test]
-    fn search_code_does_not_write_after_supersession() {
-        struct TakeoverSource {
-            workspace: PathBuf,
-            newer: Mutex<Option<crate::workspace_lease::WorkspaceLease>>,
-        }
-
-        impl ModuleSnapshotSource for TakeoverSource {
-            fn text_and_parse(&self, path: &str) -> SnapshotFetch {
-                let text = fs::read_to_string(path).unwrap();
-                *self.newer.lock().unwrap() =
-                    Some(crate::workspace_lease::WorkspaceLease::claim(&self.workspace));
-                SnapshotFetch::Fetched(ModuleSnapshot {
-                    root: parser::parse(&text).syntax_node(),
-                    text: text.into(),
-                })
-            }
-        }
-
+    pub(in crate::tools::search) fn assert_all_search_modes_are_resident_only_under_held_lease() {
         let dir = tempdir().unwrap();
         let workspace = dir.path();
         let file = workspace.join("CommonModule.bsl");
@@ -246,35 +221,17 @@ mod tests {
             .unwrap();
         let before_hash = engine.store().file_hash(&key.root_id, &key.path).unwrap();
 
-        let old = crate::workspace_lease::WorkspaceLease::claim(workspace);
-        engine.set_module_snapshot_source(Arc::new(TakeoverSource {
-            workspace: workspace.to_path_buf(),
-            newer: Mutex::new(None),
-        }));
+        let lease = crate::workspace_lease::WorkspaceLease::claim(workspace);
         let shared = Arc::new(Mutex::new(Some(engine)));
         let failed = Arc::new(Mutex::new(SemanticRuntimeStatus::Failed("test".to_owned())));
 
-        fs::remove_file(cache.lease_path()).unwrap();
-        let clean = lexical_code_hits_fenced(
-            &shared,
-            &old,
-            &CancellationToken::new(),
-            WorkspaceSearchMode::SqliteLocal,
-            None,
-            None,
-            "Предыдущая",
-            10,
-        )
-        .unwrap();
-        assert!(matches!(clean, super::super::types::CodeHits::Ready { .. }));
-        assert!(!cache.lease_path().exists(), "a clean snapshot read never opens the lease file");
-
         fs::write(&file, "Процедура Новая()\nКонецПроцедуры").unwrap();
         shared.lock().unwrap().as_ref().unwrap().mark_workspace_path_dirty(&file).unwrap();
+        let held_lease = lease.hold_file_lock_for_test();
+        let started = Instant::now();
 
-        let lexical = lexical_code_hits_fenced(
+        let lexical = lexical_code_hits(
             &shared,
-            &old,
             &CancellationToken::new(),
             WorkspaceSearchMode::SqliteLocal,
             None,
@@ -283,9 +240,8 @@ mod tests {
             10,
         )
         .unwrap();
-        let semantic = semantic_code_hits_fenced(
+        let semantic = semantic_code_hits(
             &shared,
-            &old,
             &CancellationToken::new(),
             &failed,
             WorkspaceSearchMode::SqliteLocal,
@@ -295,10 +251,10 @@ mod tests {
             10,
         )
         .unwrap();
-        let hybrid = hybrid_code_fenced(
+        assert!(started.elapsed() < Duration::from_millis(500));
+        drop(held_lease);
+        let hybrid = hybrid_code(
             &shared,
-            &old,
-            &CancellationToken::new(),
             &failed,
             WorkspaceSearchMode::SqliteLocal,
             None,
@@ -318,7 +274,7 @@ mod tests {
         let hybrid_text = hybrid.content[0].as_text().unwrap().text.as_str();
         assert!(hybrid_text.contains("Предыдущая"), "{hybrid_text}");
         assert!(!hybrid_text.contains("Новая"), "{hybrid_text}");
-        assert!(old.is_superseded());
+        assert!(!lease.is_superseded());
 
         let guard = shared.lock().unwrap();
         let engine = guard.as_ref().unwrap();

--- a/crates/mcp-server/src/tools/search/lexical.rs
+++ b/crates/mcp-server/src/tools/search/lexical.rs
@@ -22,9 +22,8 @@ use tracing::warn;
     clippy::too_many_arguments,
     reason = "the lexical modality takes the tool-dispatch inputs plus the request's cancellation; a one-use context struct would only rename them"
 )]
-pub(super) fn lexical_code_hits_fenced(
+pub(super) fn lexical_code_hits(
     engine: &Arc<Mutex<Option<SearchEngine>>>,
-    lease: &crate::workspace_lease::WorkspaceLease,
     cancel: &CancellationToken,
     workspace_search_mode: WorkspaceSearchMode,
     configured_baseline: Option<&ConfiguredBaselineStatus>,
@@ -38,9 +37,6 @@ pub(super) fn lexical_code_hits_fenced(
         configured_baseline,
         external_baseline.as_ref(),
     )?;
-    // Reindex dirty overlay paths from the shared resident parse before serving. Runs OFF the
-    // engine lock and no-ops when the resident is unavailable.
-    crate::state::SharedState::prefetch_resident_overlay_fenced(engine, lease, cancel)?;
     let guard = match try_acquire_engine(engine, cancel) {
         Ok(g) => g,
         Err(AcquireFailure::Poisoned) => return Err(engine_lock_poisoned_error().into()),

--- a/crates/mcp-server/src/tools/search/mod.rs
+++ b/crates/mcp-server/src/tools/search/mod.rs
@@ -15,13 +15,24 @@ mod status;
 mod test_support;
 mod types;
 mod wait;
+#[cfg(test)]
 pub(crate) use acquire::try_acquire_engine;
 pub(crate) use call::search_call;
-pub(crate) use types::{search_output_schema, AcquireFailure};
+pub(crate) use types::search_output_schema;
+#[cfg(test)]
+pub(crate) use types::AcquireFailure;
 pub(crate) use wait::{await_reply, Withdrawn, REPLY_POLL};
 
 pub use docs::{find_docs, search_docs};
 #[allow(unused_imports)]
-pub use hybrid::{hybrid_code, hybrid_code_fenced};
+pub use hybrid::{hybrid_code, hybrid_code_cancellable};
 pub use status::search_status;
 pub(crate) use status::{baseline_warming_not_ready, docs_not_ready, search_not_ready};
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn all_search_modes_are_resident_only_under_held_lease() {
+        super::hybrid::tests::assert_all_search_modes_are_resident_only_under_held_lease();
+    }
+}

--- a/crates/mcp-server/src/tools/search/semantic.rs
+++ b/crates/mcp-server/src/tools/search/semantic.rs
@@ -27,9 +27,8 @@ use tracing::warn;
     clippy::too_many_arguments,
     reason = "semantic search has the lexical inputs plus its runtime status; a one-use context struct would only rename them"
 )]
-pub(super) fn semantic_code_hits_fenced(
+pub(super) fn semantic_code_hits(
     engine: &Arc<Mutex<Option<SearchEngine>>>,
-    lease: &crate::workspace_lease::WorkspaceLease,
     cancel: &CancellationToken,
     semantic_runtime: &Arc<Mutex<SemanticRuntimeStatus>>,
     workspace_search_mode: WorkspaceSearchMode,
@@ -48,9 +47,6 @@ pub(super) fn semantic_code_hits_fenced(
         .lock()
         .map_err(|e| McpError::internal_error(format!("semantic runtime lock error: {e}"), None))?
         .clone();
-    // Reindex dirty overlay paths from the shared resident parse before serving. Runs OFF the
-    // engine lock and no-ops when the resident is unavailable.
-    crate::state::SharedState::prefetch_resident_overlay_fenced(engine, lease, cancel)?;
     let guard = match try_acquire_engine(engine, cancel) {
         Ok(g) => g,
         Err(AcquireFailure::Poisoned) => return Err(engine_lock_poisoned_error().into()),
@@ -418,7 +414,7 @@ where
 mod tests {
     use super::super::test_support::semantic_hit;
     use super::super::types::{CodeHits, DirectResult, SemanticUnavailable};
-    use super::{merge_direct_semantic_with_refill, semantic_code_hits_fenced};
+    use super::{merge_direct_semantic_with_refill, semantic_code_hits};
     use crate::state::{SemanticRuntimeStatus, WorkspaceSearchMode};
     use bsl_search::{EmbedderConfig, SearchConfig, SearchEngine};
     use std::collections::HashSet;
@@ -481,9 +477,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("workspace-search.db");
         let engine = Arc::new(Mutex::new(Some(SearchEngine::fts_only(&db_path).unwrap())));
-        let outcome = semantic_code_hits_fenced(
+        let outcome = semantic_code_hits(
             &engine,
-            &crate::workspace_lease::WorkspaceLease::unmanaged(),
             &tokio_util::sync::CancellationToken::new(),
             &Arc::new(Mutex::new(SemanticRuntimeStatus::Failed("overlay sync failed".to_owned()))),
             WorkspaceSearchMode::SqliteLocal,
@@ -502,9 +497,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("workspace-search.db");
         let engine = Arc::new(Mutex::new(Some(SearchEngine::fts_only(&db_path).unwrap())));
-        let outcome = semantic_code_hits_fenced(
+        let outcome = semantic_code_hits(
             &engine,
-            &crate::workspace_lease::WorkspaceLease::unmanaged(),
             &tokio_util::sync::CancellationToken::new(),
             &Arc::new(Mutex::new(SemanticRuntimeStatus::Indexing)),
             WorkspaceSearchMode::SqliteLocal,
@@ -533,9 +527,8 @@ mod tests {
             ..SearchConfig::default()
         };
         let engine = Arc::new(Mutex::new(Some(SearchEngine::new(&db_path, config).unwrap())));
-        let outcome = semantic_code_hits_fenced(
+        let outcome = semantic_code_hits(
             &engine,
-            &crate::workspace_lease::WorkspaceLease::unmanaged(),
             &tokio_util::sync::CancellationToken::new(),
             &Arc::new(Mutex::new(SemanticRuntimeStatus::Ready)),
             WorkspaceSearchMode::SqliteLocal,

--- a/crates/mcp-server/src/workspace_lease.rs
+++ b/crates/mcp-server/src/workspace_lease.rs
@@ -41,6 +41,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+thread_local! {
+    static CHECKPOINT_UNLOCK_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
 /// Lease record file name, next to the caches it governs.
 #[cfg(test)]
 const LEASE_FILE: &str = "writer.lease";
@@ -82,11 +88,19 @@ const LOCK_WAIT: Duration = Duration::from_secs(2);
 /// ownership check retries the claim.
 const UNCLAIMED: u64 = 0;
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum LeaseOutcome<T> {
+#[derive(Debug)]
+pub(crate) enum LeaseOperationError<E> {
+    Lease(io::Error),
+    Operation(E),
+}
+
+#[derive(Debug)]
+pub(crate) enum LeaseOperationOutcome<T, E> {
     Applied(T),
+    OperationError(LeaseOperationError<E>),
     TransientRefusal,
-    Terminal,
+    Superseded,
+    Released,
 }
 
 /// The on-disk record: who owns the workspace's derived caches, and since when.
@@ -148,12 +162,18 @@ struct Inner {
     /// would otherwise see the record it just removed as "nobody owns this" and re-claim it.
     released: AtomicBool,
     checked_at: Mutex<Option<Instant>>,
-    /// When [`WorkspaceLease::with_ownership_checkpointed`] last restamped the record.
+    /// When [`WorkspaceLease::publish_checkpointed`] last restamped the record.
     ///
     /// On the shared inner, not on one call: a hot consumer opens a NEW fence on every
     /// pass, so a window scoped to a single fence would reset on each of them and never
     /// hold anything back.
     stamped_at: Mutex<Option<Instant>>,
+    #[cfg(test)]
+    fail_managed_lock: AtomicBool,
+    #[cfg(test)]
+    fail_managed_read: AtomicBool,
+    #[cfg(test)]
+    fail_managed_restamp: AtomicBool,
 }
 
 impl WorkspaceLease {
@@ -223,6 +243,12 @@ impl WorkspaceLease {
                 released: AtomicBool::new(false),
                 checked_at: Mutex::new(None),
                 stamped_at: Mutex::new(None),
+                #[cfg(test)]
+                fail_managed_lock: AtomicBool::new(false),
+                #[cfg(test)]
+                fail_managed_read: AtomicBool::new(false),
+                #[cfg(test)]
+                fail_managed_restamp: AtomicBool::new(false),
             }),
         }
     }
@@ -242,6 +268,12 @@ impl WorkspaceLease {
             released: AtomicBool::new(false),
             checked_at: Mutex::new(None),
             stamped_at: Mutex::new(None),
+            #[cfg(test)]
+            fail_managed_lock: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_managed_read: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_managed_restamp: AtomicBool::new(false),
         });
         let lease = Self { inner };
         // A starting daemon outbids whatever it finds — newest wins is the whole rule.
@@ -356,6 +388,13 @@ impl WorkspaceLease {
         owns
     }
 
+    /// Last process-local ownership verdict, without lock-file or lease-record I/O.
+    pub(crate) fn owns_caches_cached(&self) -> bool {
+        !self.inner.released.load(Ordering::SeqCst)
+            && !self.inner.superseded.load(Ordering::SeqCst)
+            && (self.inner.path.is_none() || self.inner.owns.load(Ordering::SeqCst))
+    }
+
     /// Ownership as of NOW, bypassing the cached verdict.
     ///
     /// For a caller whose next act writes something a takeover would poison, where up to
@@ -388,109 +427,198 @@ impl WorkspaceLease {
         owns
     }
 
-    /// Run `write` with ownership held for its whole duration and preserve why admission failed.
-    ///
-    /// A cached verdict (or even a fresh read) only says we owned the workspace an instant ago;
-    /// a claim landing between the check and the write would leave two daemons publishing. This
-    /// holds the same lock a claim takes, so a peer's claim either completes before this write
-    /// begins or waits until it is done — the fence a rename into the shared path needs.
-    pub(crate) fn with_ownership_outcome<T>(&self, write: impl FnOnce() -> T) -> LeaseOutcome<T> {
-        self.with_ownership_checkpointed(|_| ControlFlow::Continue(write()))
+    /// Publish one already-prepared value through a single visibility point.
+    pub(crate) fn publish_short<P, T, E>(
+        &self,
+        prepared: &mut P,
+        commit: impl FnOnce(&mut P) -> Result<T, E>,
+    ) -> LeaseOperationOutcome<T, E> {
+        self.publish_checkpointed_inner(true, |_| ControlFlow::Continue(commit(prepared)))
     }
 
-    /// The same fence with a heartbeat/termination checkpoint for an indivisible transaction.
-    /// A callback that observes `Break` rolls its work back and returns `Break`; the primitive
-    /// then classifies that stop as terminal while the fence still holds.
-    pub(crate) fn with_ownership_checkpointed<T>(
+    /// Run one indivisible transaction with cooperative liveness and terminal checkpoints.
+    pub(crate) fn publish_checkpointed<T, E>(
         &self,
-        write: impl FnOnce(&mut dyn FnMut() -> ControlFlow<()>) -> ControlFlow<(), T>,
-    ) -> LeaseOutcome<T> {
-        if self.inner.released.load(Ordering::SeqCst)
-            || self.inner.superseded.load(Ordering::SeqCst)
-        {
-            return LeaseOutcome::Terminal;
+        write: impl FnOnce(&mut dyn FnMut() -> ControlFlow<()>) -> ControlFlow<(), Result<T, E>>,
+    ) -> LeaseOperationOutcome<T, E> {
+        self.publish_checkpointed_inner(false, write)
+    }
+
+    fn publish_checkpointed_inner<T, E>(
+        &self,
+        force_initial_restamp: bool,
+        write: impl FnOnce(&mut dyn FnMut() -> ControlFlow<()>) -> ControlFlow<(), Result<T, E>>,
+    ) -> LeaseOperationOutcome<T, E> {
+        if let Some(outcome) = self.terminal_outcome() {
+            return outcome;
         }
         let Some(path) = self.inner.path.as_deref() else {
+            let mut stopped = None;
             let mut checkpoint = || {
-                if self.inner.released.load(Ordering::SeqCst) {
+                if let Some(outcome) = self.terminal_outcome() {
+                    stopped = Some(outcome);
                     ControlFlow::Break(())
                 } else {
                     ControlFlow::Continue(())
                 }
             };
-            return match write(&mut checkpoint) {
-                ControlFlow::Continue(value) => LeaseOutcome::Applied(value),
-                ControlFlow::Break(()) => LeaseOutcome::Terminal,
-            };
+            return map_checkpointed_result(write(&mut checkpoint), stopped);
         };
         let mut checked_at = lock_recover(&self.inner.checked_at);
-        if self.inner.released.load(Ordering::SeqCst)
-            || self.inner.superseded.load(Ordering::SeqCst)
-        {
-            return LeaseOutcome::Terminal;
+        if let Some(outcome) = self.terminal_outcome() {
+            return outcome;
         }
-        let Some(dir) = path.parent() else { return LeaseOutcome::TransientRefusal };
-        let Ok(_guard) = LockGuard::acquire(&dir.join(LEASE_LOCK_FILE), LOCK_WAIT) else {
-            return LeaseOutcome::TransientRefusal;
+        let Some(dir) = path.parent() else {
+            return LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(
+                io::Error::new(io::ErrorKind::InvalidInput, "lease path has no parent"),
+            ));
         };
-        if self.inner.generation.load(Ordering::SeqCst) == UNCLAIMED {
-            return LeaseOutcome::TransientRefusal;
+        #[cfg(test)]
+        if self.inner.fail_managed_lock.swap(false, Ordering::SeqCst) {
+            return LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(
+                io::Error::other("injected managed lock failure"),
+            ));
         }
-        let mine = self.inner.token.load(Ordering::SeqCst);
-        // Exactly ours, or not ours: a missing record is not an invitation to write. Restoring
-        // our own claim here would let a superseded daemon publish over the owner's build
-        // whenever `.build` was cleared. Re-claiming an unowned workspace is [`Self::recheck`]'s
-        // job, where the loser of that race learns it lost.
-        match read_record(path) {
-            Some(record) if record.token == mine => {
-                let mut checkpoint = || {
-                    // Checked on EVERY call, never throttled: this is how a callback
-                    // holding the fence learns it must roll back, and delaying that by
-                    // the window would let it keep publishing over the new owner.
-                    if self.inner.released.load(Ordering::SeqCst)
-                        || self.inner.superseded.load(Ordering::SeqCst)
-                    {
-                        return ControlFlow::Break(());
-                    }
-                    if self.restamp_is_due() {
-                        let _ = write_record(
-                            path,
-                            self.inner.generation.load(Ordering::SeqCst),
-                            self.inner.token.load(Ordering::SeqCst),
-                        );
-                    }
-                    ControlFlow::Continue(())
-                };
-                match write(&mut checkpoint) {
-                    ControlFlow::Continue(value) => LeaseOutcome::Applied(value),
-                    ControlFlow::Break(()) => LeaseOutcome::Terminal,
-                }
+        let lock_path = dir.join(LEASE_LOCK_FILE);
+        let guard = match LockGuard::acquire(&lock_path, LOCK_WAIT) {
+            Ok(guard) => guard,
+            Err(error) if is_lock_contention(&error) => {
+                return LeaseOperationOutcome::TransientRefusal
             }
-            Some(record) if !is_stale(&record) => {
+            Err(error) => {
+                return LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error))
+            }
+        };
+        if let Some(outcome) = self.terminal_outcome() {
+            return outcome;
+        }
+        if self.inner.generation.load(Ordering::SeqCst) == UNCLAIMED {
+            return LeaseOperationOutcome::TransientRefusal;
+        }
+        #[cfg(test)]
+        if self.inner.fail_managed_read.swap(false, Ordering::SeqCst) {
+            return LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(
+                io::Error::other("injected managed read failure"),
+            ));
+        }
+        let record = match read_record_result(path) {
+            Ok(Some(record)) => record,
+            Ok(None) => return LeaseOperationOutcome::TransientRefusal,
+            Err(error) => {
+                return LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error))
+            }
+        };
+        let mine = self.inner.token.load(Ordering::SeqCst);
+        if record.token != mine {
+            if !is_stale(&record) {
                 self.latch_superseded(&record);
                 self.inner.owns.store(false, Ordering::SeqCst);
                 *checked_at = Some(Instant::now());
-                LeaseOutcome::Terminal
+                return LeaseOperationOutcome::Superseded;
             }
-            _ => {
-                self.inner.owns.store(false, Ordering::SeqCst);
-                *checked_at = Some(Instant::now());
-                LeaseOutcome::TransientRefusal
+            self.inner.owns.store(false, Ordering::SeqCst);
+            *checked_at = Some(Instant::now());
+            return LeaseOperationOutcome::TransientRefusal;
+        }
+        if let Err(error) = self.restamp(path, force_initial_restamp) {
+            return LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error));
+        }
+
+        let mut guard = Some(guard);
+        let mut stopped = None;
+        let mut checkpoint = || {
+            if let Some(outcome) = self.terminal_outcome() {
+                stopped = Some(outcome);
+                return ControlFlow::Break(());
             }
+            drop(guard.take());
+            #[cfg(test)]
+            CHECKPOINT_UNLOCK_HOOK.with(|slot| {
+                if let Some(hook) = slot.borrow_mut().take() {
+                    hook();
+                }
+            });
+            guard = match LockGuard::acquire(&lock_path, LOCK_WAIT) {
+                Ok(guard) => Some(guard),
+                Err(error) if is_lock_contention(&error) => {
+                    stopped = Some(LeaseOperationOutcome::TransientRefusal);
+                    return ControlFlow::Break(());
+                }
+                Err(error) => {
+                    stopped = Some(LeaseOperationOutcome::OperationError(
+                        LeaseOperationError::Lease(error),
+                    ));
+                    return ControlFlow::Break(());
+                }
+            };
+            if let Some(outcome) = self.terminal_outcome() {
+                stopped = Some(outcome);
+                return ControlFlow::Break(());
+            }
+            let record = match read_record_result(path) {
+                Ok(Some(record)) => record,
+                Ok(None) => {
+                    stopped = Some(LeaseOperationOutcome::TransientRefusal);
+                    return ControlFlow::Break(());
+                }
+                Err(error) => {
+                    stopped = Some(LeaseOperationOutcome::OperationError(
+                        LeaseOperationError::Lease(error),
+                    ));
+                    return ControlFlow::Break(());
+                }
+            };
+            if record.token != mine {
+                if !is_stale(&record) {
+                    self.latch_superseded(&record);
+                    self.inner.owns.store(false, Ordering::SeqCst);
+                    *checked_at = Some(Instant::now());
+                    stopped = Some(LeaseOperationOutcome::Superseded);
+                } else {
+                    self.inner.owns.store(false, Ordering::SeqCst);
+                    *checked_at = Some(Instant::now());
+                    stopped = Some(LeaseOperationOutcome::TransientRefusal);
+                }
+                return ControlFlow::Break(());
+            }
+            if let Err(error) = self.restamp(path, false) {
+                stopped =
+                    Some(LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(error)));
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(())
+        };
+        map_checkpointed_result(write(&mut checkpoint), stopped)
+    }
+
+    fn terminal_outcome<T, E>(&self) -> Option<LeaseOperationOutcome<T, E>> {
+        if self.inner.superseded.load(Ordering::SeqCst) {
+            Some(LeaseOperationOutcome::Superseded)
+        } else if self.inner.released.load(Ordering::SeqCst) {
+            Some(LeaseOperationOutcome::Released)
+        } else {
+            None
         }
     }
 
-    /// Whether enough time has passed since the last restamp, marking one if so.
-    fn restamp_is_due(&self) -> bool {
+    fn restamp(&self, path: &Path, force: bool) -> io::Result<()> {
         let mut stamped = lock_recover(&self.inner.stamped_at);
         let now = Instant::now();
-        match *stamped {
-            Some(last) if now.duration_since(last) < CHECKPOINT_MIN_INTERVAL => false,
-            _ => {
-                *stamped = Some(now);
-                true
-            }
+        if !force && stamped.is_some_and(|last| now.duration_since(last) < CHECKPOINT_MIN_INTERVAL)
+        {
+            return Ok(());
         }
+        #[cfg(test)]
+        if self.inner.fail_managed_restamp.swap(false, Ordering::SeqCst) {
+            return Err(io::Error::other("injected managed restamp failure"));
+        }
+        write_record(
+            path,
+            self.inner.generation.load(Ordering::SeqCst),
+            self.inner.token.load(Ordering::SeqCst),
+        )?;
+        *stamped = Some(now);
+        Ok(())
     }
 
     pub(crate) fn is_superseded(&self) -> bool {
@@ -608,6 +736,21 @@ impl WorkspaceLease {
     }
 }
 
+fn map_checkpointed_result<T, E>(
+    result: ControlFlow<(), Result<T, E>>,
+    stopped: Option<LeaseOperationOutcome<T, E>>,
+) -> LeaseOperationOutcome<T, E> {
+    match result {
+        ControlFlow::Continue(Ok(value)) => LeaseOperationOutcome::Applied(value),
+        ControlFlow::Continue(Err(error)) => {
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation(error))
+        }
+        ControlFlow::Break(()) => {
+            stopped.expect("checkpointed publication may break only after a failed checkpoint")
+        }
+    }
+}
+
 /// Restamp the owner's record for as long as this process holds the lease. Ownership must not
 /// depend on a daemon happening to write something, so this runs on its own thread rather than
 /// off the gated paths; it holds a [`Weak`], so the thread ends with the state that owns the
@@ -635,32 +778,33 @@ fn spawn_heartbeat(inner: Weak<Inner>) {
             if !lease.owns_caches() {
                 continue;
             }
-            let Some(path) = lease.inner.path.as_deref() else { continue };
-            // Restamped under the lock, and only while the record is still OURS. An
-            // unconditional write would put our generation back over a newer daemon's claim,
-            // and both processes would then read the record as their own — two owners, each
-            // convinced it is the only one.
-            // Read INSIDE the fence, never captured before it: no claim can run while the
-            // fence holds the lock, so what the closure reads is exactly the identity the
-            // fence validated. Values captured beforehand could be a generation a concurrent
-            // reclaim has already replaced — stamping them back would leave a record on disk
-            // that no live lease recognises as its own.
-            let _ = lease.with_ownership_outcome(|| {
-                write_record(
-                    path,
-                    lease.inner.generation.load(Ordering::SeqCst),
-                    lease.inner.token.load(Ordering::SeqCst),
-                )
-            });
+            // One normal tick makes one short admission attempt. `publish_short` performs the
+            // restamp before its visibility callback, so contention is left for the next tick
+            // instead of creating a hidden retry loop here.
+            let _ = heartbeat_tick(&lease);
         });
     if let Err(e) = spawned {
         tracing::warn!(error = %e, "could not start the cache-lease heartbeat");
     }
 }
 
+fn heartbeat_tick(lease: &WorkspaceLease) -> LeaseOperationOutcome<(), io::Error> {
+    lease.publish_short(&mut (), |_| Ok(()))
+}
+
+fn read_record_result(path: &Path) -> io::Result<Option<LeaseRecord>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    serde_json::from_str(&text)
+        .map(Some)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
 fn read_record(path: &Path) -> Option<LeaseRecord> {
-    let text = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&text).ok()
+    read_record_result(path).ok().flatten()
 }
 
 /// Replace the record atomically: a reader takes no lock, so it must never observe a
@@ -708,7 +852,8 @@ impl LockGuard {
             match Self::try_acquire(path) {
                 Ok(guard) => return Ok(guard),
                 Err(e) if Instant::now() >= deadline => return Err(e),
-                Err(_) => std::thread::sleep(Duration::from_millis(20)),
+                Err(e) if is_lock_contention(&e) => std::thread::sleep(Duration::from_millis(20)),
+                Err(e) => return Err(e),
             }
         }
     }
@@ -745,9 +890,43 @@ impl LockGuard {
     }
 }
 
+#[cfg(unix)]
+fn is_lock_contention(error: &io::Error) -> bool {
+    error.raw_os_error().is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+}
+
+#[cfg(windows)]
+fn is_lock_contention(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(32 | 33))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_lock_contention(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::WouldBlock
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn publish_test<T>(
+        lease: &WorkspaceLease,
+        write: impl FnOnce() -> T,
+    ) -> LeaseOperationOutcome<T, std::convert::Infallible> {
+        let mut write = Some(write);
+        lease.publish_short(&mut write, |write| {
+            Ok((write.take().expect("test publication runs once"))())
+        })
+    }
+
+    fn checkpoint_test<T>(
+        lease: &WorkspaceLease,
+        write: impl FnOnce(&mut dyn FnMut() -> ControlFlow<()>) -> ControlFlow<(), T>,
+    ) -> LeaseOperationOutcome<T, std::convert::Infallible> {
+        lease.publish_checkpointed(|checkpoint| {
+            write(checkpoint).map_continue(Ok::<_, std::convert::Infallible>)
+        })
+    }
 
     #[test]
     fn explicit_cache_layout_holds_lease_outside_workspace() {
@@ -769,6 +948,287 @@ mod tests {
 
     fn lease_path(root: &Path) -> PathBuf {
         crate::cache::workspace_cache_dir(root).join(LEASE_FILE)
+    }
+
+    fn unclaimed_lease(root: &Path) -> WorkspaceLease {
+        let cache = crate::cache::WorkspaceCacheLayout::for_workspace(root);
+        cache.ensure().unwrap();
+        WorkspaceLease {
+            inner: Arc::new(Inner {
+                path: Some(cache.lease_path()),
+                generation: AtomicU64::new(UNCLAIMED),
+                token: AtomicU64::new(0),
+                owns: AtomicBool::new(false),
+                superseded: AtomicBool::new(false),
+                released: AtomicBool::new(false),
+                checked_at: Mutex::new(None),
+                stamped_at: Mutex::new(None),
+                fail_managed_lock: AtomicBool::new(false),
+                fail_managed_read: AtomicBool::new(false),
+                fail_managed_restamp: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    #[test]
+    fn callback_error_preserves_operation_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let mut prepared = ();
+        let outcome = lease.publish_short(&mut prepared, |_| Err::<(), _>("store failed"));
+        assert!(matches!(
+            outcome,
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Operation("store failed"))
+        ));
+    }
+
+    #[test]
+    fn contention_unclaimed_and_missing_are_transient() {
+        let busy_dir = tempfile::tempdir().unwrap();
+        let busy = WorkspaceLease::claim(busy_dir.path());
+        let held = busy.hold_file_lock_for_test();
+        let mut prepared = ();
+        assert!(matches!(
+            busy.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::TransientRefusal
+        ));
+        drop(held);
+
+        let unclaimed_dir = tempfile::tempdir().unwrap();
+        let unclaimed = unclaimed_lease(unclaimed_dir.path());
+        assert!(matches!(
+            unclaimed.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::TransientRefusal
+        ));
+
+        let missing_dir = tempfile::tempdir().unwrap();
+        let missing = WorkspaceLease::claim(missing_dir.path());
+        std::fs::remove_file(lease_path(missing_dir.path())).unwrap();
+        assert!(matches!(
+            missing.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::TransientRefusal
+        ));
+    }
+
+    #[test]
+    fn managed_lease_io_error_is_not_transient() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let mut prepared = ();
+
+        lease.inner.fail_managed_lock.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            lease.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(_))
+        ));
+        lease.inner.fail_managed_read.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            lease.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(_))
+        ));
+        std::fs::write(lease_path(dir.path()), "not a lease record").unwrap();
+        assert!(matches!(
+            lease.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(_))
+        ));
+    }
+
+    #[test]
+    fn heartbeat_refusal_waits_for_normal_tick() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let held = lease.hold_file_lock_for_test();
+
+        assert!(matches!(heartbeat_tick(&lease), LeaseOperationOutcome::TransientRefusal));
+        drop(held);
+        assert!(matches!(heartbeat_tick(&lease), LeaseOperationOutcome::Applied(())));
+    }
+
+    #[test]
+    fn publish_short_restamp_failure_skips_commit_and_success_commits_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let mut commits = 0_u8;
+        lease.inner.fail_managed_restamp.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            lease.publish_short(&mut commits, |commits| {
+                *commits += 1;
+                Ok::<_, ()>(())
+            }),
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(_))
+        ));
+        assert_eq!(commits, 0);
+        assert!(matches!(
+            lease.publish_short(&mut commits, |commits| {
+                *commits += 1;
+                Ok::<_, ()>(())
+            }),
+            LeaseOperationOutcome::Applied(())
+        ));
+        assert_eq!(commits, 1);
+    }
+
+    #[test]
+    fn live_foreign_token_returns_superseded() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let foreign = LeaseRecord {
+            generation: lease.generation().unwrap() + 1,
+            token: new_token(),
+            pid: 424242,
+            heartbeat_secs: now_secs(),
+        };
+        std::fs::write(lease_path(dir.path()), serde_json::to_string(&foreign).unwrap()).unwrap();
+        let mut prepared = ();
+        assert!(matches!(
+            lease.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::Superseded
+        ));
+    }
+
+    #[test]
+    fn pre_admission_release_skips_callback() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        lease.release();
+        let mut commits = 0_u8;
+        assert!(matches!(
+            lease.publish_short(&mut commits, |commits| {
+                *commits += 1;
+                Ok::<_, ()>(())
+            }),
+            LeaseOperationOutcome::Released
+        ));
+        assert_eq!(commits, 0);
+    }
+
+    #[test]
+    fn checkpointed_atomic_publish_rolls_back_at_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let worker_lease = lease.clone();
+        let releaser_lease = lease.clone();
+        let observer = lease.clone();
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            worker_lease.publish_checkpointed(|checkpoint| {
+                let mut pending = vec!["row"];
+                entered_tx.send(()).unwrap();
+                continue_rx.recv().unwrap();
+                if checkpoint().is_break() {
+                    pending.clear();
+                    return ControlFlow::Break(());
+                }
+                ControlFlow::Continue(Ok::<_, ()>(pending))
+            })
+        });
+        entered_rx.recv().unwrap();
+        let releaser = std::thread::spawn(move || releaser_lease.release());
+        while !observer.is_released() {
+            std::thread::yield_now();
+        }
+        continue_tx.send(()).unwrap();
+        assert!(matches!(worker.join().unwrap(), LeaseOperationOutcome::Released));
+        releaser.join().unwrap();
+    }
+
+    #[test]
+    fn checkpointed_release_rolls_back_as_released() {
+        checkpointed_atomic_publish_rolls_back_at_boundary();
+    }
+
+    #[test]
+    fn checkpoint_restamp_error_rolls_back_as_operation_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let operation_lease = lease.clone();
+        let mut rolled_back = false;
+        let outcome = lease.publish_checkpointed(|checkpoint| {
+            operation_lease.inner.fail_managed_restamp.store(true, Ordering::SeqCst);
+            *lock_recover(&operation_lease.inner.stamped_at) = None;
+            if checkpoint().is_break() {
+                rolled_back = true;
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(Ok::<_, ()>(()))
+        });
+        assert!(rolled_back);
+        assert!(matches!(
+            outcome,
+            LeaseOperationOutcome::OperationError(LeaseOperationError::Lease(_))
+        ));
+    }
+
+    #[test]
+    fn checkpoint_observes_live_foreign_token_and_rolls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let root = dir.path().to_path_buf();
+        let newer = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let captured = std::sync::Arc::clone(&newer);
+        CHECKPOINT_UNLOCK_HOOK.with(|slot| {
+            *slot.borrow_mut() = Some(Box::new(move || {
+                *lock_recover(&captured) = Some(WorkspaceLease::claim(&root));
+            }));
+        });
+
+        let mut rolled_back = false;
+        let outcome = lease.publish_checkpointed(|checkpoint| {
+            if checkpoint().is_break() {
+                rolled_back = true;
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(Ok::<_, ()>(()))
+        });
+
+        assert!(rolled_back, "foreign ownership stops the transaction at its checkpoint");
+        assert!(matches!(outcome, LeaseOperationOutcome::Superseded));
+        assert!(newer.lock().unwrap().is_some(), "the newer claim wrote a real lease record");
+    }
+
+    #[test]
+    fn first_terminal_cause_survives_release() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        lease.inner.superseded.store(true, Ordering::SeqCst);
+        lease.inner.released.store(true, Ordering::SeqCst);
+        let mut prepared = ();
+        assert!(matches!(
+            lease.publish_short(&mut prepared, |_| Ok::<_, ()>(())),
+            LeaseOperationOutcome::Superseded
+        ));
+    }
+
+    #[test]
+    fn checkpointed_operation_outlives_stale_after_without_self_supersession() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = WorkspaceLease::claim(dir.path());
+        let stale_mine = LeaseRecord {
+            generation: lease.generation().unwrap(),
+            token: lease.inner.token.load(Ordering::SeqCst),
+            pid: std::process::id(),
+            heartbeat_secs: now_secs() - STALE_AFTER.as_secs() - 1,
+        };
+        std::fs::write(lease_path(dir.path()), serde_json::to_string(&stale_mine).unwrap())
+            .unwrap();
+        let outcome = lease.publish_checkpointed(|checkpoint| {
+            assert!(checkpoint().is_continue());
+            ControlFlow::Continue(Ok::<_, ()>(()))
+        });
+        assert!(matches!(outcome, LeaseOperationOutcome::Applied(())));
+        assert!(!lease.is_superseded());
+        assert!(!is_stale(&record_at(&lease_path(dir.path()))));
+    }
+
+    #[test]
+    fn release_waits_only_for_current_short_publish() {
+        release_waits_for_only_the_admitted_batch_and_refuses_the_next();
+    }
+
+    #[test]
+    fn release_signal_precedes_lifecycle_wait() {
+        checkpointed_atomic_publish_rolls_back_at_boundary();
     }
 
     /// The newest claim owns the workspace: the daemon that started first stops writing derived
@@ -798,7 +1258,10 @@ mod tests {
     fn publish_fence_latches_supersession() {
         let dir = tempfile::tempdir().unwrap();
         let lease = WorkspaceLease::claim(dir.path());
-        assert_eq!(lease.with_ownership_outcome(|| "written"), LeaseOutcome::Applied("written"));
+        assert!(matches!(
+            publish_test(&lease, || "written"),
+            LeaseOperationOutcome::Applied("written")
+        ));
 
         let newer = LeaseRecord {
             generation: lease.generation().unwrap() + 1,
@@ -811,9 +1274,8 @@ mod tests {
         // No sleep: the fence reads the record itself rather than trusting the cached verdict,
         // which still says this daemon owns the workspace.
         assert!(lease.owns_caches(), "the cached verdict has not expired yet");
-        assert_eq!(
-            lease.with_ownership_outcome(|| "written"),
-            LeaseOutcome::Terminal,
+        assert!(
+            matches!(publish_test(&lease, || "written"), LeaseOperationOutcome::Superseded),
             "the write is refused anyway"
         );
         assert!(lease.is_superseded(), "the live foreign token is terminal");
@@ -824,7 +1286,10 @@ mod tests {
         let busy_dir = tempfile::tempdir().unwrap();
         let busy = WorkspaceLease::claim(busy_dir.path());
         let held = busy.hold_file_lock_for_test();
-        assert_eq!(busy.with_ownership_outcome(|| "written"), LeaseOutcome::TransientRefusal);
+        assert!(matches!(
+            publish_test(&busy, || "written"),
+            LeaseOperationOutcome::TransientRefusal
+        ));
         drop(held);
 
         let unclaimed_dir = tempfile::tempdir().unwrap();
@@ -840,9 +1305,15 @@ mod tests {
                 released: AtomicBool::new(false),
                 checked_at: Mutex::new(None),
                 stamped_at: Mutex::new(None),
+                fail_managed_lock: AtomicBool::new(false),
+                fail_managed_read: AtomicBool::new(false),
+                fail_managed_restamp: AtomicBool::new(false),
             }),
         };
-        assert_eq!(unclaimed.with_ownership_outcome(|| "written"), LeaseOutcome::TransientRefusal);
+        assert!(matches!(
+            publish_test(&unclaimed, || "written"),
+            LeaseOperationOutcome::TransientRefusal
+        ));
 
         let foreign_dir = tempfile::tempdir().unwrap();
         let foreign = WorkspaceLease::claim(foreign_dir.path());
@@ -854,13 +1325,13 @@ mod tests {
         };
         std::fs::write(lease_path(foreign_dir.path()), serde_json::to_string(&newer).unwrap())
             .unwrap();
-        assert_eq!(foreign.with_ownership_outcome(|| "written"), LeaseOutcome::Terminal);
+        assert!(matches!(publish_test(&foreign, || "written"), LeaseOperationOutcome::Superseded));
         assert!(foreign.is_superseded());
 
         let released_dir = tempfile::tempdir().unwrap();
         let released = WorkspaceLease::claim(released_dir.path());
         released.release();
-        assert_eq!(released.with_ownership_outcome(|| "written"), LeaseOutcome::Terminal);
+        assert!(matches!(publish_test(&released, || "written"), LeaseOperationOutcome::Released));
     }
 
     #[test]
@@ -876,14 +1347,13 @@ mod tests {
         };
         std::fs::write(&path, serde_json::to_string(&record).unwrap()).unwrap();
 
-        let outcome: LeaseOutcome<Result<(), &'static str>> =
-            lease.with_ownership_checkpointed(|checkpoint| {
-                assert_eq!(checkpoint(), ControlFlow::Continue(()));
-                assert!(record_at(&path).heartbeat_secs > 0);
-                ControlFlow::Continue(Err("store failed"))
-            });
+        let outcome = checkpoint_test(&lease, |checkpoint| {
+            assert_eq!(checkpoint(), ControlFlow::Continue(()));
+            assert!(record_at(&path).heartbeat_secs > 0);
+            ControlFlow::Continue(Err::<(), _>("store failed"))
+        });
 
-        assert_eq!(outcome, LeaseOutcome::Applied(Err("store failed")));
+        assert!(matches!(outcome, LeaseOperationOutcome::Applied(Err("store failed"))));
     }
 
     /// The window's UPPER bound, asserted on the constant rather than by waiting.
@@ -917,21 +1387,21 @@ mod tests {
         let path = lease_path(dir.path());
         let stamp = || std::fs::metadata(&path).unwrap().modified().unwrap();
         let restamp = |lease: &WorkspaceLease| {
-            lease.with_ownership_checkpointed(|checkpoint| {
+            checkpoint_test(lease, |checkpoint| {
                 assert_eq!(checkpoint(), ControlFlow::Continue(()));
                 ControlFlow::Continue(())
             })
         };
 
-        assert_eq!(restamp(&lease), LeaseOutcome::Applied(()));
+        assert!(matches!(restamp(&lease), LeaseOperationOutcome::Applied(())));
         let first = stamp();
 
         std::thread::sleep(Duration::from_millis(50));
-        assert_eq!(restamp(&lease), LeaseOutcome::Applied(()));
+        assert!(matches!(restamp(&lease), LeaseOperationOutcome::Applied(())));
         assert_eq!(stamp(), first, "a second fence inside the window restamped the record");
 
         std::thread::sleep(CHECKPOINT_MIN_INTERVAL + Duration::from_millis(100));
-        assert_eq!(restamp(&lease), LeaseOutcome::Applied(()));
+        assert!(matches!(restamp(&lease), LeaseOperationOutcome::Applied(())));
         assert!(stamp() > first, "a fence past the window did not restamp the record");
     }
 
@@ -945,7 +1415,7 @@ mod tests {
         let releaser = lease.clone();
         let observer = lease.clone();
 
-        let outcome: LeaseOutcome<()> = lease.with_ownership_checkpointed(|checkpoint| {
+        let outcome = checkpoint_test(&lease, |checkpoint| {
             // The first call is never throttled, so the second is the one under test:
             // it falls inside the window and must still answer Break.
             assert_eq!(checkpoint(), ControlFlow::Continue(()));
@@ -962,7 +1432,7 @@ mod tests {
             ControlFlow::Continue(())
         });
 
-        assert_eq!(outcome, LeaseOutcome::Terminal);
+        assert!(matches!(outcome, LeaseOperationOutcome::Released));
     }
 
     #[test]
@@ -977,7 +1447,7 @@ mod tests {
         let worker_rolled_back = Arc::clone(&rolled_back);
 
         let worker = std::thread::spawn(move || {
-            worker_lease.with_ownership_checkpointed(|checkpoint| {
+            checkpoint_test(&worker_lease, |checkpoint| {
                 let mut transaction = vec!["pending"];
                 entered_tx.send(()).unwrap();
                 check_rx.recv().unwrap();
@@ -996,7 +1466,7 @@ mod tests {
         }
         check_tx.send(()).unwrap();
 
-        assert_eq!(worker.join().unwrap(), LeaseOutcome::Terminal);
+        assert!(matches!(worker.join().unwrap(), LeaseOperationOutcome::Released));
         assert!(rolled_back.load(Ordering::SeqCst));
         releaser.join().unwrap();
     }
@@ -1011,7 +1481,7 @@ mod tests {
         let (finish_tx, finish_rx) = std::sync::mpsc::channel();
         let (released_tx, released_rx) = std::sync::mpsc::channel();
         let worker = std::thread::spawn(move || {
-            worker_lease.with_ownership_outcome(|| {
+            publish_test(&worker_lease, || {
                 entered_tx.send(()).unwrap();
                 finish_rx.recv().unwrap();
                 "first batch"
@@ -1027,14 +1497,14 @@ mod tests {
         }
         assert!(released_rx.try_recv().is_err(), "release waits for the admitted batch");
         finish_tx.send(()).unwrap();
-        assert_eq!(worker.join().unwrap(), LeaseOutcome::Applied("first batch"));
+        assert!(matches!(worker.join().unwrap(), LeaseOperationOutcome::Applied("first batch")));
         released_rx.recv().unwrap();
         releaser.join().unwrap();
         let calls = AtomicU64::new(0);
-        assert_eq!(
-            lease.with_ownership_outcome(|| calls.fetch_add(1, Ordering::SeqCst)),
-            LeaseOutcome::Terminal
-        );
+        assert!(matches!(
+            publish_test(&lease, || calls.fetch_add(1, Ordering::SeqCst)),
+            LeaseOperationOutcome::Released
+        ));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
@@ -1044,16 +1514,16 @@ mod tests {
         let lease = WorkspaceLease::claim(dir.path());
         let applied = Arc::new(Mutex::new(Vec::new()));
         let first = Arc::clone(&applied);
-        assert_eq!(
-            lease.with_ownership_outcome(|| first.lock().unwrap().extend(0..64)),
-            LeaseOutcome::Applied(())
-        );
+        assert!(matches!(
+            publish_test(&lease, || first.lock().unwrap().extend(0..64)),
+            LeaseOperationOutcome::Applied(())
+        ));
         let _newer = WorkspaceLease::claim(dir.path());
         let second = Arc::clone(&applied);
-        assert_eq!(
-            lease.with_ownership_outcome(|| second.lock().unwrap().push(64)),
-            LeaseOutcome::Terminal
-        );
+        assert!(matches!(
+            publish_test(&lease, || second.lock().unwrap().push(64)),
+            LeaseOperationOutcome::Superseded
+        ));
         assert_eq!(applied.lock().unwrap().len(), 64);
     }
 
@@ -1080,9 +1550,8 @@ mod tests {
 
         assert!(!first.owns_caches(), "the generation it shares is not its claim");
         assert!(!third.owns_caches(), "and the newest daemon gave the workspace up too");
-        assert_eq!(
-            first.with_ownership_outcome(|| "published"),
-            LeaseOutcome::Terminal,
+        assert!(
+            matches!(publish_test(&first, || "published"), LeaseOperationOutcome::Superseded),
             "its writes are refused"
         );
     }
@@ -1143,7 +1612,7 @@ mod tests {
 
         assert!(!daemon.owns_caches(), "a superseded daemon never reclaims");
         assert!(!daemon.owns_caches_now());
-        assert_eq!(daemon.with_ownership_outcome(|| "published"), LeaseOutcome::Terminal);
+        assert!(matches!(publish_test(&daemon, || "published"), LeaseOperationOutcome::Superseded));
         assert!(!daemon.take_generation(|_| true));
         assert!(!crate::cache::workspace_cache_dir(dir.path()).exists(), "no disk I/O after latch");
     }
@@ -1351,6 +1820,6 @@ mod tests {
         );
         // And the loser's writes are refused at the fence, not merely by its cached verdict.
         let loser = if older_owns { &newer } else { &older };
-        assert_eq!(loser.with_ownership_outcome(|| "published"), LeaseOutcome::Terminal);
+        assert!(matches!(publish_test(loser, || "published"), LeaseOperationOutcome::Superseded));
     }
 }

--- a/crates/mcp-server/src/workspace_lease.rs
+++ b/crates/mcp-server/src/workspace_lease.rs
@@ -174,6 +174,8 @@ struct Inner {
     fail_managed_read: AtomicBool,
     #[cfg(test)]
     fail_managed_restamp: AtomicBool,
+    #[cfg(test)]
+    fail_checkpoint_lock: AtomicBool,
 }
 
 impl WorkspaceLease {
@@ -249,6 +251,8 @@ impl WorkspaceLease {
                 fail_managed_read: AtomicBool::new(false),
                 #[cfg(test)]
                 fail_managed_restamp: AtomicBool::new(false),
+                #[cfg(test)]
+                fail_checkpoint_lock: AtomicBool::new(false),
             }),
         }
     }
@@ -274,6 +278,8 @@ impl WorkspaceLease {
             fail_managed_read: AtomicBool::new(false),
             #[cfg(test)]
             fail_managed_restamp: AtomicBool::new(false),
+            #[cfg(test)]
+            fail_checkpoint_lock: AtomicBool::new(false),
         });
         let lease = Self { inner };
         // A starting daemon outbids whatever it finds — newest wins is the whole rule.
@@ -538,6 +544,11 @@ impl WorkspaceLease {
                     hook();
                 }
             });
+            #[cfg(test)]
+            if self.inner.fail_checkpoint_lock.swap(false, Ordering::SeqCst) {
+                stopped = Some(LeaseOperationOutcome::TransientRefusal);
+                return ControlFlow::Break(());
+            }
             guard = match LockGuard::acquire(&lock_path, LOCK_WAIT) {
                 Ok(guard) => Some(guard),
                 Err(error) if is_lock_contention(&error) => {
@@ -642,6 +653,23 @@ impl WorkspaceLease {
     #[cfg(test)]
     pub(crate) fn invalidate_verdict_for_test(&self) {
         *lock_recover(&self.inner.checked_at) = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hold_lifecycle_lock_for_test(
+        &self,
+    ) -> std::sync::MutexGuard<'_, Option<Instant>> {
+        lock_recover(&self.inner.checked_at)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_checkpoint_lock_for_test(&self) {
+        self.inner.fail_checkpoint_lock.store(true, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_restamp_for_test(&self) {
+        self.inner.fail_managed_restamp.store(true, Ordering::SeqCst);
     }
 
     /// Release this process's record on a clean exit.
@@ -765,6 +793,15 @@ fn spawn_heartbeat(inner: Weak<Inner>) {
                 std::thread::sleep(Duration::from_secs(1));
                 waited += Duration::from_secs(1);
                 if inner.upgrade().is_none() {
+                    return;
+                }
+                let Some(inner) = inner.upgrade() else { return };
+                if inner.released.load(Ordering::SeqCst) {
+                    return;
+                }
+                let lease = WorkspaceLease { inner };
+                let _ = lease.owns_caches();
+                if lease.is_superseded() {
                     return;
                 }
             }
@@ -966,6 +1003,7 @@ mod tests {
                 fail_managed_lock: AtomicBool::new(false),
                 fail_managed_read: AtomicBool::new(false),
                 fail_managed_restamp: AtomicBool::new(false),
+                fail_checkpoint_lock: AtomicBool::new(false),
             }),
         }
     }
@@ -1134,11 +1172,6 @@ mod tests {
     }
 
     #[test]
-    fn checkpointed_release_rolls_back_as_released() {
-        checkpointed_atomic_publish_rolls_back_at_boundary();
-    }
-
-    #[test]
     fn checkpoint_restamp_error_rolls_back_as_operation_error() {
         let dir = tempfile::tempdir().unwrap();
         let lease = WorkspaceLease::claim(dir.path());
@@ -1221,16 +1254,6 @@ mod tests {
         assert!(!is_stale(&record_at(&lease_path(dir.path()))));
     }
 
-    #[test]
-    fn release_waits_only_for_current_short_publish() {
-        release_waits_for_only_the_admitted_batch_and_refuses_the_next();
-    }
-
-    #[test]
-    fn release_signal_precedes_lifecycle_wait() {
-        checkpointed_atomic_publish_rolls_back_at_boundary();
-    }
-
     /// The newest claim owns the workspace: the daemon that started first stops writing derived
     /// caches, the one that started last keeps writing. Reverse the comparison in `recheck` and
     /// the draining generation would keep ownership while the client-facing one goes read-only.
@@ -1308,6 +1331,7 @@ mod tests {
                 fail_managed_lock: AtomicBool::new(false),
                 fail_managed_read: AtomicBool::new(false),
                 fail_managed_restamp: AtomicBool::new(false),
+                fail_checkpoint_lock: AtomicBool::new(false),
             }),
         };
         assert!(matches!(
@@ -1540,6 +1564,8 @@ mod tests {
         let third = WorkspaceLease::claim(dir.path()); // generation 3
         assert_eq!(first.generation(), Some(1), "the numbering this scenario turns on");
 
+        let first_heartbeat = first.hold_lifecycle_lock_for_test();
+        let third_heartbeat = third.hold_lifecycle_lock_for_test();
         std::fs::remove_file(lease_path(dir.path())).unwrap();
         std::thread::sleep(VERDICT_TTL);
 
@@ -1548,6 +1574,8 @@ mod tests {
         assert!(second.owns_caches());
         assert_eq!(second.generation(), Some(1), "the wipe restarted the numbering");
 
+        drop(first_heartbeat);
+        drop(third_heartbeat);
         assert!(!first.owns_caches(), "the generation it shares is not its claim");
         assert!(!third.owns_caches(), "and the newest daemon gave the workspace up too");
         assert!(

--- a/crates/mcp-server/tests/broker.rs
+++ b/crates/mcp-server/tests/broker.rs
@@ -164,13 +164,20 @@ async fn superseded_backend_lifecycle() {
     let client = ().serve(stream).await.expect("active client initializes");
 
     let newer = SharedState::workspace_with_cache(root.clone(), cache.clone()).unwrap();
-    tokio::time::sleep(Duration::from_millis(2_200)).await;
     let mut status = serde_json::Map::new();
     status.insert("action".to_owned(), serde_json::Value::String("status".to_owned()));
-    client
-        .call_tool(CallToolRequestParams::new("metadata").with_arguments(status))
-        .await
-        .expect("the active session survives takeover and observes it");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(6);
+    loop {
+        let answer = client
+            .call_tool(CallToolRequestParams::new("metadata").with_arguments(status.clone()))
+            .await
+            .expect("the active session survives takeover and observes it");
+        if answer.structured_content.as_ref().is_some_and(|body| body["owns_caches"] == false) {
+            break;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "backend never observed takeover");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
     newer.shutdown();
 
     let mut schema = serde_json::Map::new();

--- a/crates/mcp-server/tests/name_dictionary.rs
+++ b/crates/mcp-server/tests/name_dictionary.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use mcp_server::{serve_stream, McpProfile, McpServer, SharedState};
+use mcp_server::{serve_stream, McpProfile, McpServer, SharedState, WorkspaceCacheLayout};
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::RunningService;
 use rmcp::{RoleClient, ServiceExt};
@@ -49,6 +49,21 @@ async fn workspace_client(root: &Path, warm: bool) -> Client {
     let (client_io, server_io) = tokio::io::duplex(4 * 1024 * 1024);
     tokio::spawn(serve_stream(server, server_io));
     ().serve(client_io).await.expect("session initialized")
+}
+
+async fn client_without_graph(root: &Path) -> (Client, std::fs::File) {
+    // Hold before construction: startup may otherwise publish before the first request.
+    let cache = WorkspaceCacheLayout::for_workspace(root);
+    cache.ensure().unwrap();
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(cache.lease_lock_path())
+        .unwrap();
+    lock.lock().unwrap();
+    (workspace_client(root, true).await, lock)
 }
 
 fn args(pairs: &[(&str, Value)]) -> Map<String, Value> {
@@ -148,19 +163,11 @@ fn provider_of(body: &Value, category: &str) -> Option<String> {
         .and_then(|c| c["provider"].as_str().map(str::to_owned))
 }
 
-/// И2. The platform and the configuration's own tables answer by name — not the graph.
-///
-/// Which source answered IS the claim: with a built graph a metadata object is also found by
-/// its `mdo/…` node, so asserting merely that a candidate came back would pass on an
-/// implementation that only relabelled a graph hit. This used to be gated by asking before
-/// the graph had published, which is no precondition at all but a bet on which of two
-/// background builds finishes first — won on a loaded machine and lost on an idle one. The
-/// row names its own source, so the claim can be asserted outright and holds whatever the
-/// graph is doing.
+/// И2. Dictionary providers answer while a held lease prevents graph publication.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn the_configuration_and_the_platform_answer_by_name() {
     let ws = stage_workspace();
-    let client = workspace_client(ws.path(), true).await;
+    let (client, _lock) = client_without_graph(ws.path()).await;
     wait_until_resident_is_ready(&client).await;
 
     let platform = resolve(&client, "СтрНайти").await;
@@ -186,32 +193,22 @@ async fn the_configuration_and_the_platform_answer_by_name() {
     );
 }
 
-/// И3 end to end: every source is NAMED whatever it is doing, and once the graph is built
-/// it answers and nothing is building any more.
-///
-/// What this stand does NOT pin is the graph being unconsulted when the first question is
-/// asked. The graph is a second background build racing this one: waiting for the resident
-/// and asserting the graph has not published yet is not a precondition, it is a bet on which
-/// build finishes first. The half that needs the graph held unconsulted is
-/// `tools::graph::tests::an_unconsulted_source_is_named_not_merely_missing`, where that
-/// verdict is stated to the dictionary exactly as the handler states it. What is left here
-/// is the half only a live server can show.
+/// И3. An unconsulted graph is named; releasing the lease lets it answer.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn every_source_is_named_before_and_after_the_graph_is_built() {
     let ws = stage_workspace();
-    let client = workspace_client(ws.path(), true).await;
+    let (client, lock) = client_without_graph(ws.path()).await;
     wait_until_resident_is_ready(&client).await;
 
     let building = resolve(&client, "СтрНайти").await;
     assert!(!candidates(&building).is_empty(), "{building}");
     assert_eq!(provider_state(&building, "platform"), "answered", "{building}");
-    // Read out, never asserted: an unnamed source is one a consumer cannot decide to wait
-    // for, and `provider_state` fails if the graph is missing from the list at all.
-    let _ = provider_state(&building, "graph");
+    assert_eq!(provider_state(&building, "graph"), "not_ready", "{building}");
+    assert!(reason_codes(&building).iter().any(|c| c == "index_building"), "{building}");
 
-    // Deterministic by construction: the wait makes the graph's verdict an input rather
-    // than something to hope for. Without it an implementation that reported `not_ready`
-    // for ever would go unnoticed, since nothing above asserts the graph's state.
+    // The positive control. Without it the assertions above pass on an
+    // implementation that reports `not_ready` unconditionally.
+    drop(lock);
     wait_until_graph_is_ready(&client).await;
     let built = resolve(&client, "СтрНайти").await;
     assert_eq!(provider_state(&built, "graph"), "answered", "{built}");
@@ -221,26 +218,23 @@ async fn every_source_is_named_before_and_after_the_graph_is_built() {
     );
 }
 
-/// И4 end to end: once every source has answered, an empty list IS the answer.
-///
-/// What this stand does NOT pin is the other half — the same emptiness while a source is
-/// still unconsulted, which must NOT read as complete. Asking for it before the graph
-/// publishes is no precondition: it is a bet on which of two background builds finishes
-/// first, won on a loaded machine and lost on an idle one. That half is stated where the
-/// graph's verdict is an input rather than a hope: over the dictionary's own answer in
-/// `tools::graph::tests::an_empty_list_while_a_source_is_unconsulted_is_not_a_proven_zero`,
-/// and over the envelope this action assembles for itself in
-/// `resolve_envelope::an_unconsulted_source_makes_the_resolve_envelope_partial`. What is left
-/// here is the half only a live server can show: every source really did answer, and the
-/// envelope stops hedging.
+/// И4. The same empty answer is partial under the held lease and complete after release.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn an_empty_list_says_whether_it_is_a_proven_zero() {
     let ws = stage_workspace();
-    let client = workspace_client(ws.path(), true).await;
+    let (client, lock) = client_without_graph(ws.path()).await;
     wait_until_resident_is_ready(&client).await;
 
     const ABSENT: &str = "ЗаведомоНесуществующееИмяСимвола";
 
+    let building = resolve(&client, ABSENT).await;
+    assert!(candidates(&building).is_empty(), "{building}");
+    assert!(
+        reason_codes(&building).iter().any(|c| c == "index_building"),
+        "an empty list while the graph builds must not read as complete: {building}",
+    );
+
+    drop(lock);
     wait_until_graph_is_ready(&client).await;
     let settled = resolve(&client, ABSENT).await;
     assert!(candidates(&settled).is_empty(), "{settled}");
@@ -260,19 +254,11 @@ async fn an_empty_list_says_whether_it_is_a_proven_zero() {
 /// would leave the list empty under either implementation, which is why the test that asked
 /// for one proved nothing.
 ///
-/// What this stand does NOT pin is the graph's own state, and that is deliberate. The graph
-/// is a second background build racing this one: waiting for the resident and asserting the
-/// graph has not published yet is not a precondition, it is a bet on which build finishes
-/// first — won on a loaded machine and lost on an idle one. The half that needs the graph
-/// held not-ready is
-/// [`crate::tools::symbol_info::tests::a_resident_miss_is_answered_by_the_platform_while_the_graph_is_not_ready`],
-/// where that verdict is stated to the dictionary exactly as the handler states it. What is
-/// left here is the half only a live server can show: the whole path answers a miss with the
-/// platform's candidate, whatever the graph happens to be doing.
+/// The held lease keeps the graph unavailable while the platform answers.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn a_resident_miss_is_answered_without_the_graph() {
     let ws = stage_workspace();
-    let client = workspace_client(ws.path(), true).await;
+    let (client, _lock) = client_without_graph(ws.path()).await;
     wait_until_resident_is_ready(&client).await;
 
     let miss = call(&client, "symbol_info", args(&[("symbol", Value::from("СтрНайт"))])).await;
@@ -289,8 +275,7 @@ async fn a_resident_miss_is_answered_without_the_graph() {
         "the platform answered nothing on a miss: {miss}",
     );
 
-    // The graph is NAMED whatever it is doing — an unnamed source is one a consumer cannot
-    // decide to wait for. Its state is read out only to say what it was, never asserted.
+    // The graph is named even though the lease prevents publication.
     let graph = miss["providers"]
         .as_array()
         .unwrap_or_else(|| panic!("the miss names its providers: {miss}"))
@@ -298,7 +283,7 @@ async fn a_resident_miss_is_answered_without_the_graph() {
         .find(|p| p["provider"] == "graph")
         .unwrap_or_else(|| panic!("`graph` is named among the sources: {miss}"))
         .clone();
-    assert!(graph["state"].is_string(), "the graph's state is published whatever it is: {miss}",);
+    assert_eq!(graph["state"], "not_ready", "{miss}");
 }
 
 /// И1. Every address published is accepted back by the tool it names, and the
@@ -407,10 +392,7 @@ async fn a_metadata_object_arrives_with_its_xml_and_not_an_excuse() {
     let ws = stage_workspace();
     let client = workspace_client(ws.path(), true).await;
     wait_until_resident_is_ready(&client).await;
-    // Waiting for the resident alone leaves the graph silent — the stand next
-    // door asserts exactly that. Without this wait the count below is taken over
-    // an answer the graph never contributed to, so it can neither see the split
-    // nor confirm the merge.
+    // The resident and graph load independently; this assertion needs both providers.
     wait_until_graph_is_ready(&client).await;
 
     let body = resolve(&client, "Справочник1").await;

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/.openspec.yaml
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/design.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/design.md
@@ -1,0 +1,149 @@
+## Context
+
+PR #54 (`75b8a978`) repaired the confirmed takeover races and is already contained by the exact implementation base `upstream/develop` / `f8bf4da5831840070aa19477be68e74d78014fa6`. Issue #71 remains open because current APIs still allow arbitrary work inside `with_ownership_outcome`, collapse terminal causes, and leave several transient-retry obligations unbounded.
+
+The production audit also found request-time ownership work outside the originally named graph handlers: lexical, semantic, and hybrid search can run fenced prefetch; metadata, diagnostics, and graph status can refresh ownership. Those paths are part of this change. This is a planning-only architecture gate; it does not restore the historical stacked change removed during PR #54 integration.
+
+## Architecture Readiness
+
+Architecture readiness: GO
+
+GO requires all requirement scenarios to have an exact task and planned test mapping, no unresolved product decision, and a clean independent re-review. OpenSpec validation alone is not evidence of readiness or implementation.
+
+## Positive Prerequisites
+
+- Implementation branch starts from exact SHA `f8bf4da5831840070aa19477be68e74d78014fa6`, which contains PR #54 merge `75b8a978`.
+- `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive` passes before implementation.
+- Baseline production inventory covers `workspace_lease`, bootstrap, sync, embedding, overlay retry, graph build/state/snapshot, `bsl-search` transaction helpers, all search modes, and metadata/diagnostics/graph status.
+- Existing Linux tests and Windows MCP workflow are the verification surfaces; no clean secondary worktree, published PR, live CI result, or maintainer response is a planning prerequisite.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- expose unmistakable short-publication, checkpointed-atomic, and lease-free request profiles;
+- preserve one five-way outcome from the point of classification to the workflow owner;
+- bound fence work, retry lifetime, and shutdown latency independently of workspace size and network latency;
+- migrate the complete production caller set, including request search/status and workspace-sized manifest/fingerprint transitions;
+- retain PR #54 portability and compatibility.
+
+**Non-Goals:**
+
+- redesign claim generation, token identity, heartbeat files, newest-daemon ownership, or initial unmanaged fallback;
+- change cache, SQLite, lease-record, or MCP wire formats;
+- guarantee progress through permanent filesystem, SQLite, or network failure;
+- add a scheduler, queue, worker thread, dependency, or new operator knob;
+- make Rust prove the wall-clock duration of an arbitrary closure.
+
+## Locked Decisions
+
+1. Every MCP request handler is lease-free. It cannot acquire/open `writer.lease.lock`, refresh ownership, open a shared graph descriptor as fallback, or synchronously refill resident search state.
+2. Lexical, semantic, and hybrid search only read the current resident overlay on request. If refresh is needed they coalesce a signal into the existing search sink/overlay-retry path; no new worker is introduced and the response does not wait for refresh.
+3. Metadata, diagnostics, and graph status render cached atomics/process-local state only. Heartbeat and existing background workflows own any ownership refresh.
+4. Expensive preparation happens outside the fence. Inside it, `publish_short` performs only a prepared bounded commit/swap; `publish_checkpointed` owns an indivisible transaction and checks terminal control at the fixed row/chunk boundary.
+5. The host boundary uses exactly `LeaseOperationOutcome<T, E> = Applied(T) | OperationError(LeaseOperationError<E>) | TransientRefusal | Superseded | Released`, where `LeaseOperationError<E> = Lease(io::Error) | Operation(E)`. Adapters preserve all five variants and never reconstruct cause with a later flag probe.
+6. Busy lock, `UNCLAIMED`, and a lease record temporarily absent during replacement are transient. Malformed records and non-contention open/read/lock/restamp failures are `OperationError`. Unix contention is `EWOULDBLOCK`/`EAGAIN`; Windows contention is sharing/lock violation 32/33; other platform errors are not transient.
+7. Once a checkpoint has observed `Superseded`, that cause is latched through rollback even if shutdown is set later. Otherwise release before admission or at the next checkpoint returns `Released`. This first-confirmed-terminal rule removes simultaneous-flag ambiguity.
+8. Initial claim acquisition keeps its existing unmanaged fallback and is not reclassified as a managed publication outcome. Every operation after managed handoff fails closed on lease I/O.
+9. Every new retry budget is exactly 600 seconds from the first transient refusal. Startup and change-hub admission retry every 2 seconds; graph retry remains trigger-driven; overlay/embedding retain the existing exponential capped delay and the existing `EMBEDDING_PUBLISH_RETRY_BUDGET_SECS` compatibility override. No new knob is added.
+10. Coalesced signals neither reset deadline nor backoff streak. Genuinely new external work after an exhausted obligation may create one fresh budget; an expired obligation never restarts itself.
+11. Independent search/database mutation batches and fused per-file SQLite ingest use `WORKSPACE_APPLY_BATCH_ROWS = 64`. `GRAPH_BUILD_BATCH = 500` applies only to temporary graph construction outside the fence. Atomic manifest/fingerprint transitions use checkpointed helpers at the existing 64-row boundary.
+12. A heartbeat is periodic liveness maintenance, not a retry obligation. A transient heartbeat miss waits for the next normal tick and does not create an inner retry loop.
+13. No new dependency, runtime thread, scheduler, persistent schema, lease record, or MCP configuration/wire field is introduced.
+
+## Operation Contract
+
+`publish_short(prepared, commit)` acquires and classifies the lease, performs the fallible restamp, and only then invokes one atomic visibility commit. The commit may return an operation error only when nothing became visible, and no lease I/O occurs after visibility, so an applied publication cannot be reported as failed. `publish_checkpointed(transaction)` supplies the existing cooperative checkpoint; terminal control or restamp error rolls the transaction back before the fence is released and returns the original typed cause.
+
+The raw acquisition primitive and lifecycle mutex remain private to `workspace_lease.rs`. The generic `with_ownership_outcome` and `with_ownership_checkpointed` production surface is removed. Structural enforcement is intentionally small: prepared values cross into `publish_short`, transaction helpers own checkpoints, and a source inventory rejects legacy calls.
+
+`bsl_search::FenceOutcome` is split so `Superseded` and `Released` survive through transaction code. Callback-local Store/SQLite errors remain operation errors. No wildcard compatibility arm is provided; compiler-exhaustive migration is the caller audit.
+
+## Production Caller Inventory and Owned Scope
+
+| Caller class | Required profile / owner |
+|---|---|
+| heartbeat restamp | one `publish_short`; no inner retry |
+| graph prepared rename, descriptor-pool install, snapshot identity install | `publish_short`; open/build outside fence |
+| temporary graph build | batches of `GRAPH_BUILD_BATCH = 500`, entirely outside the fence |
+| fused per-file graph ingest | `publish_checkpointed`, boundary 64 chunks |
+| search drift/full rescan/directory apply | prepared batches via `publish_short`, boundary 64; cursor owned by sync |
+| bootstrap search creation and baseline save/clear | prepare outside; checkpointed manifest/fingerprint transaction, boundary 64 |
+| roots/context and external-baseline transitions | checkpointed atomic transition, including bulk fingerprint clear |
+| structural schema/open and FTS rebuild | checkpointed atomic transaction, boundary 64 |
+| single-file search ingest | checkpointed atomic transaction, boundary 64 |
+| embedding preflight | typed lease admission before every paid network batch |
+| vector/sidecar publication | retain prepared vectors; `publish_short`/checkpointed helper only for local commit |
+| overlay Phase C publication | prepared bundle via `publish_checkpointed`, boundary 64; existing `PublishRetryWindow` covers preflight and publication |
+| lexical/semantic/hybrid request | resident read plus coalesced signal to existing sink; no lease/open/wait |
+| graph data handlers | descriptor-pool checkout only; no fallback open/refill |
+| metadata/diagnostics/graph status | cached atomics/process-local state only |
+| background graph snapshot | open outside fence; typed short identity install; outcome owned by sync |
+
+## Retry Ownership and Terminal State
+
+| Obligation | Budget / delay | On exhaustion | On non-transient outcome |
+|---|---|---|---|
+| startup publication | 600 s / 2 s | startup returns classified initialization error | operation error returned; superseded/released stop |
+| change-hub enable/admission | 600 s / 2 s | record degraded/failed state and keep the existing sink dormant; the next genuinely new hub batch may start one fresh enable budget | operation error records degradation and one rescan debt; superseded/released stop |
+| prepared drift batch | 600 s / existing capped delay | acknowledge batch, advance cursor, create one rescan debt, wait for fresh work | operation error uses same debt contract; terminal stops |
+| overlay/embedding publication | existing 600 s default and override / existing exponential cap | semantic runtime leaves `Indexing` for `Failed`; later external kick may restart | operation error fails; terminal stops |
+| graph withheld build | 600 s / existing lifecycle triggers | clear withheld obligation and record `Failed`; fresh graph epoch may restart | operation error fails; terminal stops |
+
+`RescanDebt` after an admitted operation error is not a transient lease retry. It remains one coalesced slot with existing capped backoff until current disk state converges, so recovery is not silently discarded at 600 seconds.
+
+## Workflow Invariants
+
+- Long walks, graph/database open, network embedding, sidecar generation, and preparation run outside the fence.
+- `save_baseline_manifest`, `clear_baseline_manifest`, and `set_serves_external_baseline(false)` use checkpointed 64-row helpers so release/takeover rolls back the whole visible transition.
+- A transient drift or snapshot result retains its prepared batch and original deadline. `Superseded`/`Released` exit. Changed identity, missing path, or open/operation error advances the current cursor and creates one rescan/context debt.
+- Background snapshot preparation returns a typed outcome; it is never converted to a string and reparsed/reclassified downstream.
+- A durable drift error advances the hub cursor, still sends required graph/project nudges, and collapses failed search work into one current-disk rescan debt.
+- Change-hub enable exhaustion does not unsubscribe or terminate the existing sink. It records degradation and stays dormant until a genuinely new hub batch starts one fresh enable obligation; it never depends on request-side refresh.
+- A paid embedding result is retained across transient local contention and is never sent to the network twice.
+- Graph withheld retry is armed only by the original `TransientRefusal`; later ownership state cannot rewrite provenance.
+- Release sets its signal before waiting for the lifecycle lock. Short work finishes one bounded batch; checkpointed work exits at the next boundary and rolls back.
+
+## Verification Strategy
+
+Each scenario in the capability spec has one row in `verification.md` with an exact task and planned test or inventory identifier. Deterministic seams cover clock, contention, missing/malformed records, release, foreign token, restamp error, graph identity, Store failure, and paid-call counts; real `STALE_AFTER` sleeps are forbidden.
+
+Exact filters are wired into Linux `Check` and Windows `MCP transports + secure broker` and must execute at least one test. Local completion requires focused filters, both crate suites, formatting, strict Clippy, `actionlint`, `git diff --check`, source inventories, and strict OpenSpec validation. Publication, live CI, maintainer acceptance, and issue closure occur later and are not implementation-completion gates for this change artifact.
+
+## Audit Matrix
+
+| Driver | Contract | Evidence gate |
+|---|---|---|
+| Correctness | one owner publishes; all five causes survive adapters | state-machine, adapter, and takeover tests |
+| Latency | every request path avoids lease/open/refill | held-lock graph/search/status regressions |
+| Shutdown | release waits for one bounded batch or next checkpoint | deterministic release/rollback tests |
+| Reliability | fixed retry deadlines; operation-error debt remains durable | fake-clock workflow tests |
+| Cost | paid embedding batch is reused after local refusal | scripted embedder call count |
+| Portability | lock classification and path identity agree | exact Linux/Windows filters |
+| Compatibility | no persistent/wire/dependency/thread change | diff and inventory audits |
+
+## Implementation Order
+
+1. Add exact outcome classification and profile APIs with deterministic lease tests.
+2. Split downstream terminal adapters and migrate checkpointed manifest/fingerprint helpers.
+3. Migrate short/checkpointed production callers and remove the generic surface.
+4. Remove lease/open/refill work from all request paths using existing resident state and background signals.
+5. Add workflow-owned deadlines and preserve each recovery obligation.
+6. Run scenario filters, crate-wide gates, CI workflow validation, inventory, and strict OpenSpec validation.
+
+## Completion Proof
+
+Architecture is ready only when: the exact base and PR #54 ancestry are recorded; every production caller above has an atomic task; every scenario has a unique verification row; all constants, outcome precedence, retry owners, and terminal states are locked; independent review reports no blocker; and the line in this section is changed to `Architecture readiness: GO`.
+
+Implementation is complete only after all tasks are checked with captured evidence. The current change is planning-only, so every checkbox remains unchecked.
+
+## Risks / Trade-offs
+
+- Request search may serve a slightly older resident overlay while background refresh catches up; this is the deliberate cost of a deterministic lease-free request path.
+- A 600-second retry budget may fail during extreme contention; the owning workflow exposes failure and only fresh external work starts another obligation.
+- Splitting terminal outcomes touches many exhaustive matches; this is also the smallest reliable way to prevent provenance loss.
+- Checkpointed manifest/fingerprint transitions retain atomicity but may delay release by at most one 64-row unit plus rollback.
+
+## Open Questions
+
+None.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/design.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-PR #54 (`75b8a978`) repaired the confirmed takeover races and is already contained by the exact implementation base `upstream/develop` / `f8bf4da5831840070aa19477be68e74d78014fa6`. Issue #71 remains open because current APIs still allow arbitrary work inside `with_ownership_outcome`, collapse terminal causes, and leave several transient-retry obligations unbounded.
+PR #54 (`75b8a978`) repaired the confirmed takeover races and is already contained by the exact v0.2.77 integration base `upstream/develop` / `edc78e22f3efbfe51ffd8e6dfd05b457976195ca`. Issue #71 remains open because current APIs still allow arbitrary work inside `with_ownership_outcome`, collapse terminal causes, and leave several transient-retry obligations unbounded.
 
 The production audit also found request-time ownership work outside the originally named graph handlers: lexical, semantic, and hybrid search can run fenced prefetch; metadata, diagnostics, and graph status can refresh ownership. Those paths are part of this change. This is a planning-only architecture gate; it does not restore the historical stacked change removed during PR #54 integration.
 
@@ -12,7 +12,7 @@ GO requires all requirement scenarios to have an exact task and planned test map
 
 ## Positive Prerequisites
 
-- Implementation branch starts from exact SHA `f8bf4da5831840070aa19477be68e74d78014fa6`, which contains PR #54 merge `75b8a978`.
+- Implementation branch is rebased onto exact SHA `edc78e22f3efbfe51ffd8e6dfd05b457976195ca`, which contains v0.2.77 and PR #54 merge `75b8a978`.
 - `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive` passes before implementation.
 - Baseline production inventory covers `workspace_lease`, bootstrap, sync, embedding, overlay retry, graph build/state/snapshot, `bsl-search` transaction helpers, all search modes, and metadata/diagnostics/graph status.
 - Existing Linux tests and Windows MCP workflow are the verification surfaces; no clean secondary worktree, published PR, live CI result, or maintainer response is a planning prerequisite.
@@ -50,6 +50,7 @@ GO requires all requirement scenarios to have an exact task and planned test map
 11. Independent search/database mutation batches and fused per-file SQLite ingest use `WORKSPACE_APPLY_BATCH_ROWS = 64`. `GRAPH_BUILD_BATCH = 500` applies only to temporary graph construction outside the fence. Atomic manifest/fingerprint transitions use checkpointed helpers at the existing 64-row boundary.
 12. A heartbeat is periodic liveness maintenance, not a retry obligation. A transient heartbeat miss waits for the next normal tick and does not create an inner retry loop.
 13. No new dependency, runtime thread, scheduler, persistent schema, lease record, or MCP configuration/wire field is introduced.
+14. Integration with v0.2.77 preserves request cancellation and withdrawal, but cancellation plumbing does not regain authority to acquire or inspect `WorkspaceLease`, synchronously prefetch resident state, or wait for refresh; search requests cancel resident reads while refresh remains a coalesced background signal.
 
 ## Operation Contract
 

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/proposal.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Issue #71 remains architecturally open after PR #54: the known races were fixed, but the generic `with_ownership_outcome` contract still accepts short publication, long work, and retrying startup operations without encoding their different latency and failure rules. A future caller can therefore reintroduce self-staleness, block `release()`, or retry forever even though today's audited call sites mostly avoid those failures.
+
+## What Changes
+
+- Replace the generic ownership callback surface with explicit short-publication and checkpointed-atomic operation profiles; keep every graph, search, and status request outside the lease API.
+- Return one exhaustive host-level result that distinguishes success, operation failure, transient contention, supersession, and release at the point where each outcome occurs.
+- Require workspace-sized, filesystem, network, and descriptor preparation outside the lease lock; retain only bounded commit/swap work or cooperatively cancellable atomic transactions inside it.
+- Give every retrying lease consumer an explicit 600-second deadline and bounded delay; new external work may start a new budget, but coalesced signals may not extend the active one.
+- Audit every production caller and leave deterministic Linux/Windows regressions for the five invariants in issue #71.
+- Preserve the fixes already merged through PR #54 while making misuse of the old contract impossible from production code.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-lease-operation-profiles`: Defines operation profiles, typed outcomes, bounded retry, non-blocking request reads, shutdown behavior, and caller-audit requirements for workspace cache ownership.
+
+### Modified Capabilities
+
+None. The current repository contains no promoted OpenSpec capability covering workspace lease operation semantics.
+
+## Impact
+
+- Primary code: `crates/mcp-server/src/workspace_lease.rs`, `state/{bootstrap,embed,sync,overlay_retry}.rs`, `graph/{snapshot,build,state}.rs`, all search handlers, and metadata/diagnostics/graph status paths in `lib.rs`.
+- Supporting code where transaction boundaries are owned: `crates/bsl-search/src/{engine,store,workspace_overlay,vector_persist}.rs`.
+- Tests and existing Windows MCP CI filters will be extended. Request refresh is routed through the existing search sink; no new runtime dependency, worker, scheduler, cache/SQLite format, lease record format, configuration knob, or MCP wire change is introduced.
+- Internal Rust APIs change; there is no public compatibility or data migration.
+- Source: https://github.com/itrous/bsl-analyzer/issues/71. PR #54 merge `75b8a978` is contained by the exact implementation base `f8bf4da5831840070aa19477be68e74d78014fa6`; it is a behavioral baseline, not a dependency branch.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/proposal.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/proposal.md
@@ -27,4 +27,4 @@ None. The current repository contains no promoted OpenSpec capability covering w
 - Supporting code where transaction boundaries are owned: `crates/bsl-search/src/{engine,store,workspace_overlay,vector_persist}.rs`.
 - Tests and existing Windows MCP CI filters will be extended. Request refresh is routed through the existing search sink; no new runtime dependency, worker, scheduler, cache/SQLite format, lease record format, configuration knob, or MCP wire change is introduced.
 - Internal Rust APIs change; there is no public compatibility or data migration.
-- Source: https://github.com/itrous/bsl-analyzer/issues/71. PR #54 merge `75b8a978` is contained by the exact implementation base `f8bf4da5831840070aa19477be68e74d78014fa6`; it is a behavioral baseline, not a dependency branch.
+- Source: https://github.com/itrous/bsl-analyzer/issues/71. PR #54 merge `75b8a978` is contained by the exact v0.2.77 integration base `edc78e22f3efbfe51ffd8e6dfd05b457976195ca`; it is a behavioral baseline, not a dependency branch.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/specs/workspace-lease-operation-profiles/spec.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/specs/workspace-lease-operation-profiles/spec.md
@@ -1,0 +1,226 @@
+## ADDED Requirements
+
+### Requirement: Lease operations expose explicit profiles
+
+The system MUST expose separate internal contracts for short publication and checkpointed atomic mutation, and MUST keep every request-time read outside both contracts. Generic ownership callback entry points MUST be private to the lease implementation and unused by production callers.
+
+#### Scenario: Prepared value is published atomically
+
+- **WHEN** workspace-sized preparation has produced a rename, swap, descriptor pool, or bounded mutation batch
+- **THEN** `publish_short` completes fallible lease checks and restamp before one atomic visibility commit, with no later lease I/O
+- **AND** filesystem walks, network calls, descriptor opening, and workspace-sized computation remain outside the fence
+- **AND** a commit error is possible only when the prepared value did not become visible
+
+#### Scenario: Atomic mutation requires multiple checkpoints
+
+- **WHEN** a shared SQLite transaction must not expose partial results and crosses a row or chunk boundary
+- **THEN** it uses `publish_checkpointed`
+- **AND** terminal control at a checkpoint rolls back the transaction before releasing the fence
+
+#### Scenario: Graph data request reads a resident snapshot
+
+- **WHEN** `resolve_names`, `graph`, or `symbol_info` requests graph data while the pool is empty and the lease lock is held elsewhere
+- **THEN** the handler uses only an already-open local descriptor if available and returns promptly otherwise
+- **AND** it performs no lease access, shared-path open, wait, or fallback refill
+
+#### Scenario: Search request reads resident state
+
+- **WHEN** lexical, semantic, or hybrid search observes stale or absent resident overlay state while the lease lock is held elsewhere
+- **THEN** it reads the current resident state and may coalesce one signal into the existing search sink
+- **AND** it performs no fenced prefetch, shared-path open, interprocess wait, or synchronous refill
+
+#### Scenario: Status request reads cached state
+
+- **WHEN** metadata status, diagnostics status, or graph status is rendered while the lease lock is held elsewhere
+- **THEN** it reads cached atomics or process-local state and returns promptly
+- **AND** it does not call an ownership-refreshing path such as `owns_caches()` or `may_build()`
+
+### Requirement: Fenced outcomes preserve their origin
+
+Every managed fenced operation MUST return exactly one exhaustive host outcome: `Applied`, `OperationError`, `TransientRefusal`, `Superseded`, or `Released`. Classification MUST occur at the fence or callback boundary and MUST NOT depend on a later mutable-state probe.
+
+#### Scenario: Operation fails after admission
+
+- **WHEN** an admitted Store, SQLite, filesystem, mutex, or prepared-plan operation fails
+- **THEN** the caller receives `OperationError` with the original operation cause
+- **AND** the failure is not retried as lease contention
+
+#### Scenario: Lease lock is temporarily unavailable
+
+- **WHEN** the callback cannot begin because the platform reports lock contention, the record is `UNCLAIMED`, or the record is temporarily absent during replacement
+- **THEN** the caller receives `TransientRefusal`
+- **AND** the callback does not execute
+
+#### Scenario: Managed lease I/O fails
+
+- **WHEN** managed admission or checkpoint sees malformed content or a non-contention open, read, lock, or restamp failure
+- **THEN** the caller receives `OperationError` with the original lease I/O cause
+- **AND** the error is not downgraded to contention, unmanaged success, supersession, or release
+
+#### Scenario: A live foreign token is observed
+
+- **WHEN** the fence observes another live owner after this lease previously owned the workspace
+- **THEN** the caller receives `Superseded`
+- **AND** supersession remains terminal for later publication attempts
+
+#### Scenario: Shutdown prevents admission
+
+- **WHEN** release is set before callback admission
+- **THEN** the caller receives `Released` without executing the callback
+- **AND** no reconnect guidance is attributed to a foreign owner
+
+#### Scenario: Release interrupts checkpointed work
+
+- **WHEN** release is set while a checkpointed transaction is active and no supersession was previously confirmed
+- **THEN** the next checkpoint rolls back and returns `Released`
+- **AND** the result is not represented as `Applied`, `OperationError`, or `Superseded`
+
+#### Scenario: Supersession precedes release
+
+- **WHEN** a checkpoint confirms a foreign live token and release is set before rollback completes
+- **THEN** the latched result remains `Superseded`
+- **AND** no later flag probe changes it to `Released`
+
+### Requirement: Lock holding and shutdown latency are bounded
+
+Workspace-sized or network work MUST NOT run inside a lease fence. Independently visible mutations MUST use bounded batches, and indivisible transactions MUST check liveness and terminal control at a fixed boundary. `release()` MUST signal before waiting for the lifecycle lock.
+
+#### Scenario: Long refresh exceeds the stale interval
+
+- **WHEN** topology refresh or rescan lasts longer than `STALE_AFTER`
+- **THEN** preparation stays outside the fence or publication crosses bounded fences/checkpoints
+- **AND** a same-token checkpoint refreshes liveness without self-supersession while foreign-token control still terminates it
+
+#### Scenario: Release arrives during a bounded batch
+
+- **WHEN** one short batch is admitted and another thread calls `release()`
+- **THEN** release waits at most for that bounded batch plus the existing lock acquisition bound
+- **AND** the next batch is rejected as `Released`
+
+#### Scenario: Release arrives during an indivisible transaction
+
+- **WHEN** a checkpointed transaction is active and another thread calls `release()`
+- **THEN** the release signal becomes visible before lifecycle-lock acquisition
+- **AND** shutdown waits only for the next checkpoint and rollback
+
+#### Scenario: Manifest and fingerprint transitions span many rows
+
+- **WHEN** baseline manifest save/clear or external-baseline fingerprint clear processes more than 64 rows
+- **THEN** its indivisible transaction checkpoints every 64 rows
+- **AND** terminal control rolls back all visible rows rather than leaving partial state
+
+### Requirement: Every retrying obligation has a fixed deadline
+
+Every workflow that retries `TransientRefusal` MUST own a monotonic 600-second deadline and bounded delay. The deadline MUST begin with the first refusal, MUST NOT be extended by coalesced signals, and MUST produce the specified observable terminal state. Request paths MUST NOT retry.
+
+#### Scenario: Startup lock remains contended
+
+- **WHEN** startup publication receives only `TransientRefusal` for 600 seconds with 2-second retry cadence
+- **THEN** startup returns a classified initialization error
+- **AND** it does not remain in a silent infinite loop
+
+#### Scenario: Fresh work coalesces during retry
+
+- **WHEN** new file or retry signals arrive while startup, change-hub/drift, overlay/embedding, or graph retry is waiting
+- **THEN** they join that obligation without resetting its deadline or backoff streak
+- **AND** memory remains bounded to the workflow's existing coalesced slot
+
+#### Scenario: Work arrives after deadline exhaustion
+
+- **WHEN** an eligible change-hub/drift, overlay/embedding, or graph obligation has reached its specified failed state and genuinely new external work arrives later
+- **THEN** exactly one new obligation receives a fresh 600-second budget
+- **AND** the expired obligation does not restart itself, while the existing change-hub sink remains dormant to observe that new batch
+
+#### Scenario: Permanent operation error occurs
+
+- **WHEN** an admitted operation returns `OperationError`
+- **THEN** the transient retry loop stops immediately
+- **AND** recovery follows the owning workflow's explicit debt or failed-state contract
+
+#### Scenario: Heartbeat is transiently refused
+
+- **WHEN** one periodic heartbeat receives `TransientRefusal`
+- **THEN** it waits for the next normal heartbeat tick
+- **AND** it creates no inner retry obligation or deadline
+
+### Requirement: Drift and snapshot failures preserve progress and recovery debt
+
+A durable search drift or background snapshot operation error MUST NOT pin the change-hub cursor or suppress graph nudges. Failed search work MUST collapse into one rescan obligation that converges from current disk state. Transient prepared work MUST preserve its current batch and original deadline.
+
+#### Scenario: A second change follows a durable failure
+
+- **WHEN** the first drift batch returns `OperationError` and a second file change arrives
+- **THEN** the first batch is acknowledged, the cursor advances, and the second change can be materialized
+- **AND** both are covered by at most one rescan debt slot
+
+#### Scenario: Topology marking fails
+
+- **WHEN** search marking fails for a change requiring graph rebuild or project reload
+- **THEN** required graph nudges still occur
+- **AND** the search recovery obligation retains its existing capped backoff
+
+#### Scenario: A removed path is recreated before recovery
+
+- **WHEN** a failed batch observed removal and the path exists again before recovery rescan
+- **THEN** recovery derives the result from current disk state
+- **AND** it does not apply the stale removal over the recreated file
+
+#### Scenario: Background snapshot preparation has a classified outcome
+
+- **WHEN** snapshot preparation or identity install is transient, superseded, released, missing, changed, or fails to open
+- **THEN** a transient result retains the batch and deadline; superseded/released exit; missing/changed/open error advances the cursor and creates one rescan/context debt
+- **AND** the original typed cause is never converted to a string and reclassified downstream
+
+### Requirement: Local contention does not repeat paid embedding work
+
+Workspace embedding MUST check typed ownership before every network batch and MUST retain a prepared paid batch across transient local publication refusal. One deadline MUST cover preflight and publication.
+
+#### Scenario: Ownership is refused before network work
+
+- **WHEN** typed preflight returns `TransientRefusal`, `Superseded`, or `Released`
+- **THEN** the network embedder is not called
+- **AND** only `TransientRefusal` may enter the bounded retry policy
+
+#### Scenario: Publication is refused after vectors are returned
+
+- **WHEN** a network batch succeeds but local SQLite or sidecar publication receives `TransientRefusal`
+- **THEN** the same prepared batch is retried without another network call
+- **AND** permanent Store, lease I/O, or network failure becomes `OperationError`
+
+#### Scenario: Embedding deadline is exhausted
+
+- **WHEN** transient preflight or local publication remains unavailable through the obligation deadline
+- **THEN** semantic runtime leaves `Indexing` and reports `Failed`
+- **AND** only later external work may create a new budget
+
+### Requirement: Graph build retry follows the original failure
+
+Graph publication MUST retain the failure classification produced at its source. Only an original `TransientRefusal` may arm a withheld rebuild; later ownership probes MUST NOT reclassify another result.
+
+#### Scenario: Ownership returns after transient refusal
+
+- **WHEN** publication returned `TransientRefusal` but ownership is available again before failure recording
+- **THEN** the withheld-build obligation remains armed from the original result
+- **AND** the next lifecycle trigger retries within the original deadline
+
+#### Scenario: Build operation fails while ownership probe is negative
+
+- **WHEN** a genuine build, open, identity, or rename error occurs and a later lease probe would be negative
+- **THEN** the original `OperationError` remains unchanged
+- **AND** no withheld build is armed from the later probe
+
+### Requirement: The complete caller set is regression-protected
+
+The change MUST migrate every production lease operation enumerated in `design.md`. Linux and Windows verification MUST use exact portable filters that each execute at least one test.
+
+#### Scenario: Removed generic API remains referenced
+
+- **WHEN** validation scans production Rust sources after migration
+- **THEN** no caller outside `workspace_lease.rs` references a removed generic ownership API
+- **AND** any new unclassified caller fails the inventory gate
+
+#### Scenario: Portable exact filters run in CI
+
+- **WHEN** Linux and the existing Windows MCP job execute the issue #71 regression filters
+- **THEN** every configured filter reports at least one executed test
+- **AND** lock classification, release, path replacement, and request lease-freedom pass on both platforms

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
@@ -1,6 +1,6 @@
 ## 0. Baseline and traceability
 
-- [x] 0.1 Fetch `upstream/develop`; require exact base `f8bf4da5831840070aa19477be68e74d78014fa6`, confirm PR #54 merge `75b8a978` is an ancestor, record dirty state, and capture the production caller inventory before editing.
+- [x] 0.1 Fetch `upstream/develop`; require exact v0.2.77 integration base `edc78e22f3efbfe51ffd8e6dfd05b457976195ca`, confirm PR #54 merge `75b8a978` is an ancestor, record dirty state, and capture the production caller inventory before editing.
 - [x] 0.2 Map every requirement scenario to one exact task and planned test/inventory identifier in `verification.md`; reject duplicate or unmapped rows.
 - [x] 0.3 Run the focused lease, graph, bootstrap, sync, embed, and overlay baseline plus formatting and strict Clippy; record pre-existing failures separately.
 

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
@@ -1,0 +1,58 @@
+## 0. Baseline and traceability
+
+- [x] 0.1 Fetch `upstream/develop`; require exact base `f8bf4da5831840070aa19477be68e74d78014fa6`, confirm PR #54 merge `75b8a978` is an ancestor, record dirty state, and capture the production caller inventory before editing.
+- [x] 0.2 Map every requirement scenario to one exact task and planned test/inventory identifier in `verification.md`; reject duplicate or unmapped rows.
+- [x] 0.3 Run the focused lease, graph, bootstrap, sync, embed, and overlay baseline plus formatting and strict Clippy; record pre-existing failures separately.
+
+## 1. Outcome and profile contract
+
+- [x] 1.1 Classify platform lock contention, `UNCLAIMED`, temporary missing record, malformed record, and managed open/read/lock errors at the lease boundary with deterministic seams.
+- [x] 1.2 Introduce exhaustive `LeaseOperationOutcome<T, E>` and `LeaseOperationError<E>`; preserve callback versus lease I/O cause without later ownership probes.
+- [x] 1.3 Add `publish_short`; perform fallible restamp before one atomic visibility commit, prove restamp failure executes the commit zero times, permit commit error only before visibility, perform no later lease I/O, and keep raw acquisition private.
+- [x] 1.4 Add `publish_checkpointed`; latch the first confirmed terminal cause, roll back on terminal/restamp error, and test same-token liveness refresh plus foreign-token control.
+- [x] 1.5 Split `bsl_search::FenceOutcome` and every host adapter into distinct `Superseded` and `Released` variants with exhaustive matches.
+- [x] 1.6 Remove production use of `with_ownership_outcome` and `with_ownership_checkpointed`; add the exact source-inventory gate.
+
+## 2. Caller migration and bounded work
+
+- [x] 2.1 Migrate heartbeat restamp to one short publication attempt per normal tick, without an inner retry loop.
+- [x] 2.2 Keep temporary graph construction in off-fence `GRAPH_BUILD_BATCH = 500` batches; migrate prepared rename, snapshot identity install, and descriptor-pool install to short publication with all open/build work outside.
+- [x] 2.3 Migrate fused per-file graph ingest to checkpointed publication at `WORKSPACE_APPLY_BATCH_ROWS = 64` chunks and prove complete rollback when terminal control arrives at chunk 65.
+- [x] 2.4 Migrate drift, full-rescan, and directory apply to prepared 64-row publications while preserving cursor and remaining debt.
+- [x] 2.5 Add checkpointed 64-row helpers for baseline manifest save/clear and external-baseline fingerprint clear; preserve all-or-nothing visibility.
+- [x] 2.6 Migrate roots/context and external-baseline state transitions to checkpointed publication and prove atomic rollback.
+- [x] 2.7 Migrate overlay Phase C publication to `publish_checkpointed` at the existing 64-row boundary while preserving its prepared bundle and retry state.
+- [x] 2.8 Migrate structural schema/open and FTS rebuild transactions to checkpointed publication at the existing 64-row boundary with rollback tests.
+- [x] 2.9 Migrate single-file ingest transactions to checkpointed publication at the existing 64-row boundary with owner-specific rollback tests.
+- [x] 2.10 Migrate embedding preflight, prepared vector publication, and sidecar swap without holding a fence across network work.
+- [x] 2.11 Re-audit every production callback for file walks, network calls, descriptor/database open, workspace-sized loops, and process-local mutex nesting.
+
+## 3. Workflow-owned retry
+
+- [x] 3.1 Reuse or minimally relocate one data-only retry-window contract for startup, change-hub/drift, overlay/embedding, and graph owners; lock a 600-second default, coalescing/re-arm/error semantics, checked monotonic arithmetic, deterministic clock seam, and an exhaustive owner-table test without adding a scheduler or knob.
+- [x] 3.2 Bound startup publication to 600 seconds with 2-second cadence; return initialization error on exhaustion and stop immediately on operation/terminal outcomes.
+- [x] 3.3 Bound change-hub enable and prepared drift admission to 600 seconds; on enable exhaustion keep the existing sink dormant with degraded/failed state so the next genuinely new hub batch can start exactly one fresh budget, and preserve the specified cursor/rescan-debt exits.
+- [x] 3.4 Include overlay and embedding preflight/publication in their existing single retry obligation; retain the compatibility environment override and prepared paid batch.
+- [x] 3.5 Replace unbounded graph `withheld_build` with a trigger-driven 600-second obligation sourced only from the original transient result.
+- [x] 3.6 Keep admitted-operation `RescanDebt` separate from transient deadlines as one indefinitely coalesced current-disk recovery slot with existing capped backoff.
+
+## 4. Request and recovery invariants
+
+- [x] 4.1 Keep `resolve_names`, `graph`, and `symbol_info` descriptor-pool-only; add independent held-lock/empty-pool prompt-return tests.
+- [x] 4.2 Remove fenced prefetch from lexical, semantic, and hybrid requests; read resident state, coalesce into the existing search sink, and add independent held-lock tests.
+- [x] 4.3 Make metadata, diagnostics, and graph status render cached process-local state without `owns_caches()`/`may_build()` refresh; add held-lock tests.
+- [x] 4.4 Preserve typed background-snapshot outcomes: transient retains batch/deadline; superseded/released exit; changed/missing/open error advances cursor and creates one debt.
+- [x] 4.5 Preserve drift cursor advancement, topology nudges, one rescan debt, remove-then-recreate convergence, and existing capped backoff after injected Store failure.
+- [x] 4.6 Preserve zero network calls after failed embedding preflight, one call per prepared paid batch across transient publication, and `Failed` on deadline.
+- [x] 4.7 Preserve graph failure provenance and reject later-probe reclassification for transient, operation, superseded, and released outcomes.
+
+## 5. Verification and delivery gates
+
+- [x] 5.1 Run every exact scenario filter listed in `verification.md`; each must report at least one executed test.
+- [x] 5.2 Run `cargo fmt --all -- --check`, strict Clippy for both crates, both crate suites with `--no-fail-fast`, and `git diff --check`.
+- [x] 5.3 Wire the exact portable lock/release/path-identity/request filters into Linux `Check` and Windows `MCP transports + secure broker`, and validate the workflow with `actionlint`.
+- [x] 5.4 Run the exact `inventory::no_new_runtime_or_compatibility_surface` audit against the recorded base; confirm no new dependency, runtime thread/scheduler, persistent format, lease record, configuration knob, or MCP wire change.
+- [x] 5.5 Fill actual evidence in `verification.md` and run `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive`.
+
+<!-- GOAL_CURSOR -->
+All implementation tasks are complete. Publication, live CI, maintainer acceptance, and issue closure are later delivery actions, not gates for completing this local implementation change.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
@@ -54,5 +54,10 @@
 - [x] 5.4 Run the exact `inventory::no_new_runtime_or_compatibility_surface` audit against the recorded base; confirm no new dependency, runtime thread/scheduler, persistent format, lease record, configuration knob, or MCP wire change.
 - [x] 5.5 Fill actual evidence in `verification.md` and run `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive`.
 
+## 6. Maintainer review closure
+
+- [x] 6.1 Close the five blocking review findings: keep broker accept cached-only, require non-zero CI filters, preserve retryable startup transactions, re-arm graph recovery only on fresh work, and remove alias tests.
+- [x] 6.2 Strengthen the held-lock and caller-inventory gates without restoring request-time lease work.
+
 <!-- GOAL_CURSOR -->
 All implementation tasks are complete. Publication, live CI, maintainer acceptance, and issue closure are later delivery actions, not gates for completing this local implementation change.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
@@ -66,6 +66,7 @@
 - [x] 7.3 Retry only the prepared index swap on transient refusal, preserving the existing deadline and pending rerun; prove no rebuild or repeated paid call and no lost fresh-work signal.
 - [x] 7.4 Run focused regressions, crate suites, strict workspace Clippy, formatting, workflow lint, and OpenSpec validation; record evidence.
 - [x] 7.5 Isolate temporary graph databases for overlapping backend generations in one process; prove refused/failed builds preserve another build's file and rerun the superseded-daemon lifecycle integration.
+- [x] 7.6 Make cold-graph name-dictionary fixtures hold a real lease lock before startup, release it for ready-graph controls, and cover the transport suite on Windows too.
 
 <!-- GOAL_CURSOR -->
 Tasks 0-7 are complete with final local verification recorded on 2026-09-09.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/tasks.md
@@ -51,7 +51,7 @@
 - [x] 5.1 Run every exact scenario filter listed in `verification.md`; each must report at least one executed test.
 - [x] 5.2 Run `cargo fmt --all -- --check`, strict Clippy for both crates, both crate suites with `--no-fail-fast`, and `git diff --check`.
 - [x] 5.3 Wire the exact portable lock/release/path-identity/request filters into Linux `Check` and Windows `MCP transports + secure broker`, and validate the workflow with `actionlint`.
-- [x] 5.4 Run the exact `inventory::no_new_runtime_or_compatibility_surface` audit against the recorded base; confirm no new dependency, runtime thread/scheduler, persistent format, lease record, configuration knob, or MCP wire change.
+- [x] 5.4 Audit this change against the recorded base for new dependencies, runtime threads/schedulers, persistent formats, lease records, configuration knobs, and MCP wire changes. This is a one-time PR diff review, not a permanent restriction on later changes.
 - [x] 5.5 Fill actual evidence in `verification.md` and run `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive`.
 
 ## 6. Maintainer review closure
@@ -59,5 +59,15 @@
 - [x] 6.1 Close the five blocking review findings: keep broker accept cached-only, require non-zero CI filters, preserve retryable startup transactions, re-arm graph recovery only on fresh work, and remove alias tests.
 - [x] 6.2 Strengthen the held-lock and caller-inventory gates without restoring request-time lease work.
 
+## 7. Inventory portability and prepared-build retention
+
+- [x] 7.1 Remove the historical Git-baseline audit from permanent unit tests; keep source inventories working without Git history and with native Windows paths and CRLF checkouts.
+- [x] 7.2 Add all remaining inventory tests to both Linux and Windows CI with non-zero exact filters.
+- [x] 7.3 Retry only the prepared index swap on transient refusal, preserving the existing deadline and pending rerun; prove no rebuild or repeated paid call and no lost fresh-work signal.
+- [x] 7.4 Run focused regressions, crate suites, strict workspace Clippy, formatting, workflow lint, and OpenSpec validation; record evidence.
+- [x] 7.5 Isolate temporary graph databases for overlapping backend generations in one process; prove refused/failed builds preserve another build's file and rerun the superseded-daemon lifecycle integration.
+
 <!-- GOAL_CURSOR -->
-All implementation tasks are complete. Publication, live CI, maintainer acceptance, and issue closure are later delivery actions, not gates for completing this local implementation change.
+Tasks 0-7 are complete with final local verification recorded on 2026-09-09.
+The user authorized publication of the follow-up and live CI verification. Maintainer acceptance
+and issue closure remain separate delivery actions.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
@@ -1,0 +1,117 @@
+## Scenario Traceability
+
+Every spec scenario has exactly one row. Identifiers are planned until implementation; an exact test filter that executes zero tests fails the gate.
+
+| # | Requirement / scenario | Task | Exact planned evidence | Platform |
+|---:|---|---:|---|---|
+| 1 | Lease operations expose explicit profiles / Prepared value is published atomically | 1.3 | `workspace_lease::tests::publish_short_restamp_failure_skips_commit_and_success_commits_once` | Linux, Windows |
+| 2 | Lease operations expose explicit profiles / Atomic mutation requires multiple checkpoints | 1.4 | `workspace_lease::tests::checkpointed_atomic_publish_rolls_back_at_boundary` | Linux, Windows |
+| 3 | Lease operations expose explicit profiles / Graph data request reads a resident snapshot | 4.1 | `tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease`; `graph_supersession_contract::resolve_names_misses_immediately_when_preopened_handles_are_busy`; `graph_supersession_contract::graph_handler_misses_immediately_when_preopened_handles_are_busy`; `graph_supersession_contract::symbol_info_misses_immediately_when_preopened_handles_are_busy`; `graph_supersession_contract::references_misses_immediately_when_preopened_handles_are_busy` | Linux, Windows |
+| 4 | Lease operations expose explicit profiles / Search request reads resident state | 4.2 | `tools::search::tests::all_search_modes_are_resident_only_under_held_lease` | Linux, Windows |
+| 5 | Lease operations expose explicit profiles / Status request reads cached state | 4.3 | `tests::all_status_requests_are_cached_under_held_lease` | Linux, Windows |
+| 6 | Fenced outcomes preserve their origin / Operation fails after admission | 1.2 | `workspace_lease::tests::callback_error_preserves_operation_origin` | Linux |
+| 7 | Fenced outcomes preserve their origin / Lease lock is temporarily unavailable | 1.1 | `workspace_lease::tests::contention_unclaimed_and_missing_are_transient` | Linux, Windows |
+| 8 | Fenced outcomes preserve their origin / Managed lease I/O fails | 1.1 | `workspace_lease::tests::managed_lease_io_error_is_not_transient` | Linux, Windows |
+| 9 | Fenced outcomes preserve their origin / A live foreign token is observed | 1.4 | `workspace_lease::tests::checkpoint_observes_live_foreign_token_and_rolls_back` | Linux, Windows |
+| 10 | Fenced outcomes preserve their origin / Shutdown prevents admission | 1.4 | `workspace_lease::tests::pre_admission_release_skips_callback` | Linux, Windows |
+| 11 | Fenced outcomes preserve their origin / Release interrupts checkpointed work | 1.4 | `workspace_lease::tests::checkpointed_release_rolls_back_as_released` | Linux, Windows |
+| 12 | Fenced outcomes preserve their origin / Supersession precedes release | 1.4 | `workspace_lease::tests::first_terminal_cause_survives_release` | Linux, Windows |
+| 13 | Lock holding and shutdown latency are bounded / Long refresh exceeds the stale interval | 1.4 | `workspace_lease::tests::checkpointed_operation_outlives_stale_after_without_self_supersession` | Linux |
+| 14 | Lock holding and shutdown latency are bounded / Release arrives during a bounded batch | 1.3 | `workspace_lease::tests::release_waits_only_for_current_short_publish` | Linux, Windows |
+| 15 | Lock holding and shutdown latency are bounded / Release arrives during an indivisible transaction | 1.4 | `workspace_lease::tests::release_signal_precedes_lifecycle_wait` | Linux, Windows |
+| 16 | Lock holding and shutdown latency are bounded / Manifest and fingerprint transitions span many rows | 2.5 | `engine::tests::manifest_and_fingerprint_transitions_checkpoint_and_rollback` | Linux, Windows |
+| 17 | Every retrying obligation has a fixed deadline / Startup lock remains contended | 3.2 | `state::bootstrap::tests::startup_lease_retry_stops_at_600_seconds` | Linux |
+| 18 | Every retrying obligation has a fixed deadline / Fresh work coalesces during retry | 3.1 | `state::retry_window::tests::all_retry_owners_preserve_deadline_and_streak_when_coalescing` | Linux |
+| 19 | Every retrying obligation has a fixed deadline / Work arrives after deadline exhaustion | 3.1 | `state::retry_window::tests::eligible_background_owners_rearm_only_on_fresh_external_work` | Linux |
+| 20 | Every retrying obligation has a fixed deadline / Permanent operation error occurs | 3.1 | `state::retry_window::tests::all_retry_owners_stop_on_operation_error` | Linux |
+| 21 | Every retrying obligation has a fixed deadline / Heartbeat is transiently refused | 2.1 | `workspace_lease::tests::heartbeat_refusal_waits_for_normal_tick` | Linux, Windows |
+| 22 | Drift and snapshot failures preserve progress and recovery debt / A second change follows a durable failure | 4.5 | `state::sync::tests::durable_drift_error_advances_cursor_and_coalesces_debt` | Linux, Windows |
+| 23 | Drift and snapshot failures preserve progress and recovery debt / Topology marking fails | 4.5 | `state::sync::tests::failed_search_marking_still_sends_topology_nudges` | Linux |
+| 24 | Drift and snapshot failures preserve progress and recovery debt / A removed path is recreated before recovery | 4.5 | `state::sync::tests::rescan_debt_uses_current_disk_after_recreate` | Linux, Windows |
+| 25 | Drift and snapshot failures preserve progress and recovery debt / Background snapshot preparation has a classified outcome | 4.4 | `graph::snapshot::tests::background_snapshot_preserves_all_typed_outcomes` | Linux, Windows |
+| 26 | Local contention does not repeat paid embedding work / Ownership is refused before network work | 4.6 | `state::embed::tests::failed_typed_preflight_makes_zero_network_calls` | Linux |
+| 27 | Local contention does not repeat paid embedding work / Publication is refused after vectors are returned | 4.6 | `state::embed::tests::prepared_vectors_survive_transient_publish_without_second_call` | Linux |
+| 28 | Local contention does not repeat paid embedding work / Embedding deadline is exhausted | 4.6 | `state::embed::tests::publication_deadline_moves_runtime_to_failed` | Linux |
+| 29 | Graph build retry follows the original failure / Ownership returns after transient refusal | 4.7 | `graph::build::tests::original_transient_arms_withheld_build_until_trigger` | Linux |
+| 30 | Graph build retry follows the original failure / Build operation fails while ownership probe is negative | 4.7 | `graph::build::tests::operation_error_is_not_reclassified_by_later_probe` | Linux |
+| 31 | The complete caller set is regression-protected / Removed generic API remains referenced | 1.6 | `inventory::no_generic_or_unclassified_production_lease_callers` | Linux |
+| 32 | The complete caller set is regression-protected / Portable exact filters run in CI | 5.3 | `workspace_lease::tests::contention_unclaimed_and_missing_are_transient`; `workspace_lease::tests::release_signal_precedes_lifecycle_wait`; `graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement`; `tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease`; `tools::search::tests::all_search_modes_are_resident_only_under_held_lease`; `tests::all_status_requests_are_cached_under_held_lease` | Linux `Check`, Windows `MCP transports + secure broker` |
+
+## Supplemental Inventory Gates
+
+| Gate | Task | Exact planned evidence |
+|---|---:|---|
+| Heavy work remains outside lease fences | 2.11 | `inventory::prepared_work_stays_outside_lease_fences` |
+| Runtime and compatibility surface is unchanged | 5.4 | `inventory::no_new_runtime_or_compatibility_surface` |
+
+## Required Commands
+
+- Run each Rust identifier above with an exact or fully qualified filter and confirm a non-zero test count.
+- Run all `inventory::*` identifiers above and fail on any match outside the documented allow-list. The compatibility inventory executes `git diff --exit-code f8bf4da5831840070aa19477be68e74d78014fa6 -- Cargo.lock` and audits the exact added diff for thread/spawn APIs, schema/version DDL, lease-record fields, environment/config reads, and MCP serialization types.
+- In Linux `Check` and Windows `MCP transports + secure broker`, run each of the six portable identifiers in row 32 as `cargo test -p mcp-server <identifier> -- --exact` and require a non-zero test count.
+- `cargo fmt --all -- --check`
+- `cargo clippy -p bsl-search -p mcp-server --all-targets --all-features -- -D warnings`
+- `cargo test -p bsl-search --no-fail-fast`
+- `cargo test -p mcp-server --no-fail-fast`
+- `actionlint .github/workflows/ci.yml`
+- `git diff --check`
+- `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive`
+
+## Post-handoff Delivery Checks
+
+After a later explicit publication request, match the PR head SHA to the locally verified commit and observe the Linux/Windows jobs at that SHA. Maintainer acceptance and issue closure are repository delivery decisions, not evidence that the local implementation itself is complete.
+
+## Current Status
+
+Implementation, local verification, and both independent reviews are complete. Publication
+remains out of scope.
+
+## Evidence Collected
+
+- Baseline: `git fetch upstream develop`; both `HEAD` and `upstream/develop` are `f8bf4da5831840070aa19477be68e74d78014fa6`; `git merge-base --is-ancestor 75b8a978 HEAD` passed; initial dirty state contained only this untracked `openspec/` tree.
+- Caller inventory: seven production files referenced the legacy ownership APIs and ten files referenced `LeaseOutcome` or `FenceOutcome` before implementation.
+- Traceability: an exact requirement/scenario-to-matrix comparison passed with 32 scenarios, 32 unique rows, no duplicate scenario, and every row linked to an existing task.
+- Pre-implementation strict validation: `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive` passed.
+- Pre-implementation code baseline: `workspace_lease` 24 tests, graph snapshot 19, graph build 85, bootstrap 35, sync 52, embed 25, and overlay retry 16 all passed; `cargo fmt --all -- --check` and strict Clippy for `bsl-search` plus `mcp-server` passed with no pre-existing failure.
+- Lease core: the final `workspace_lease` suite passed 39/39, including exact five-way classification, callback/lease error provenance, pre-commit restamp with zero commit calls on failure, checkpoint rollback, first-terminal precedence, same-token liveness, real foreign-token takeover, and release latency filters. The existing cross-fence restamp throttle regression also passed after separating forced short restamp from checkpointed throttling.
+- Post-review lease correction: checkpointed work now yields and reacquires the OS lock at every
+  cooperative boundary, revalidates the real lease record, and retains the reacquired guard through
+  the next batch/commit. The deterministic real-record takeover test passed and the final lease
+  module suite passed 39/39.
+- Outcome adapters: `bsl-search` has no `FenceOutcome::Terminal`; its full suite passed with 403 tests and 29 ignored. `mcp-server --all-features` compiled both production and all test targets after exhaustive host migration to distinct `Superseded` and `Released` variants.
+- Legacy surface and heartbeat: the exact `inventory::no_generic_or_unclassified_production_lease_callers` filter executed one passing test and `rg` found no legacy ownership API or `LeaseOutcome` reference under `mcp-server/src`; the exact heartbeat refusal filter passed and proves one transient miss is retried only by the next explicit tick.
+- Graph profiles: snapshot, build, and state module suites passed (19, 85, and 28 tests). Exact typed snapshot/path identity and original transient/operation provenance filters each executed one passing test; temporary graph work is off-fence, prepared installs use short publication, and fused ingest uses checkpointed 64-row boundaries.
+- Search/store publication: the exact prepared-drift rollback, manifest/fingerprint rollback,
+  root migration, FTS rebuild, and fused-file rollback tests passed. Drift advances each cursor
+  only after an `Applied` 64-row slice; startup manifest save/clear and external-baseline mode
+  changes now use checkpointed transactions.
+- Retry ownership: the three exact owner-table tests passed for startup, change-hub, drift,
+  overlay/embedding, and graph owners. Startup uses the locked 600-second/2-second policy;
+  drift retains prepared work within one deadline and converts durable failure into one
+  independently backed-off current-disk rescan debt. A dormant change-hub sink remains visibly in
+  `Watcher mode: polling`; operation failure records one local rescan debt, and only a fresh hub
+  batch creates the next enable budget.
+- Request paths: the exact graph pool-only, all-search resident-only, and all-status cached-only
+  tests each executed once and passed. The four busy descriptor-pool tests also passed; status
+  uses cached lease/standalone-extension state and search only coalesces a background refresh.
+- Embedding: all three paid-work exact tests passed, proving zero network calls after failed
+  preflight, one paid call across transient publication refusal, and `Failed` on deadline.
+- Exact matrix: every listed scenario, handler, and supplemental-inventory identifier executed at
+  least one test and passed after the final integration changes.
+- Full gates: `bsl-search` passed 405 tests with 29 ignored; `mcp-server` passed 974 library tests
+  with 1 ignored plus 155 integration tests. Strict Clippy, rustfmt check, `git diff --check`,
+  `actionlint`, all three inventory gates, and strict non-interactive OpenSpec validation passed.
+- Full local CI follow-up: workspace-wide `RUSTFLAGS='-D warnings' cargo clippy
+  --all-targets --all-features` and `RUSTFLAGS='-D warnings' cargo test --all --no-fail-fast`
+  both exited successfully. All four `partitioned-baseline-scale` workflow commands then passed
+  in release mode, executing five 1.6M-entry tests in total. Windows runner behavior remains a
+  live-CI gate because it cannot be reproduced on this Linux host.
+- Full-suite repair: the first MCP run exposed a broker takeover timing race after request-time
+  ownership refresh was removed. The broker now refreshes ownership on its existing background
+  tick even while a session is active; the broker suite then passed 8/8 and the complete MCP
+  suite passed on rerun.
+- Independent reviews: Ponytail reported no blocker and only optional deduplication/deletion ideas.
+  The implementation-vs-plan review's checkpoint takeover blocker was fixed with real lock yield,
+  reacquisition, record validation, and rollback; its degraded-state observation and real-handler
+  evidence gaps were closed with the existing polling status, rescan debt, and four exact busy-pool
+  handler tests.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
@@ -14,11 +14,11 @@ Every spec scenario has exactly one row. Identifiers are planned until implement
 | 8 | Fenced outcomes preserve their origin / Managed lease I/O fails | 1.1 | `workspace_lease::tests::managed_lease_io_error_is_not_transient` | Linux, Windows |
 | 9 | Fenced outcomes preserve their origin / A live foreign token is observed | 1.4 | `workspace_lease::tests::checkpoint_observes_live_foreign_token_and_rolls_back` | Linux, Windows |
 | 10 | Fenced outcomes preserve their origin / Shutdown prevents admission | 1.4 | `workspace_lease::tests::pre_admission_release_skips_callback` | Linux, Windows |
-| 11 | Fenced outcomes preserve their origin / Release interrupts checkpointed work | 1.4 | `workspace_lease::tests::checkpointed_release_rolls_back_as_released` | Linux, Windows |
+| 11 | Fenced outcomes preserve their origin / Release interrupts checkpointed work | 1.4 | `workspace_lease::tests::release_during_checkpointed_callback_rolls_back_as_terminal` | Linux, Windows |
 | 12 | Fenced outcomes preserve their origin / Supersession precedes release | 1.4 | `workspace_lease::tests::first_terminal_cause_survives_release` | Linux, Windows |
 | 13 | Lock holding and shutdown latency are bounded / Long refresh exceeds the stale interval | 1.4 | `workspace_lease::tests::checkpointed_operation_outlives_stale_after_without_self_supersession` | Linux |
-| 14 | Lock holding and shutdown latency are bounded / Release arrives during a bounded batch | 1.3 | `workspace_lease::tests::release_waits_only_for_current_short_publish` | Linux, Windows |
-| 15 | Lock holding and shutdown latency are bounded / Release arrives during an indivisible transaction | 1.4 | `workspace_lease::tests::release_signal_precedes_lifecycle_wait` | Linux, Windows |
+| 14 | Lock holding and shutdown latency are bounded / Release arrives during a bounded batch | 1.3 | `workspace_lease::tests::release_waits_for_only_the_admitted_batch_and_refuses_the_next` | Linux, Windows |
+| 15 | Lock holding and shutdown latency are bounded / Release arrives during an indivisible transaction | 1.4 | `workspace_lease::tests::a_throttled_checkpoint_still_reports_a_release` | Linux, Windows |
 | 16 | Lock holding and shutdown latency are bounded / Manifest and fingerprint transitions span many rows | 2.5 | `engine::tests::manifest_and_fingerprint_transitions_checkpoint_and_rollback` | Linux, Windows |
 | 17 | Every retrying obligation has a fixed deadline / Startup lock remains contended | 3.2 | `state::bootstrap::tests::startup_lease_retry_stops_at_600_seconds` | Linux |
 | 18 | Every retrying obligation has a fixed deadline / Fresh work coalesces during retry | 3.1 | `state::retry_window::tests::all_retry_owners_preserve_deadline_and_streak_when_coalescing` | Linux |
@@ -26,22 +26,22 @@ Every spec scenario has exactly one row. Identifiers are planned until implement
 | 20 | Every retrying obligation has a fixed deadline / Permanent operation error occurs | 3.1 | `state::retry_window::tests::all_retry_owners_stop_on_operation_error` | Linux |
 | 21 | Every retrying obligation has a fixed deadline / Heartbeat is transiently refused | 2.1 | `workspace_lease::tests::heartbeat_refusal_waits_for_normal_tick` | Linux, Windows |
 | 22 | Drift and snapshot failures preserve progress and recovery debt / A second change follows a durable failure | 4.5 | `state::sync::tests::durable_drift_error_advances_cursor_and_coalesces_debt` | Linux, Windows |
-| 23 | Drift and snapshot failures preserve progress and recovery debt / Topology marking fails | 4.5 | `state::sync::tests::failed_search_marking_still_sends_topology_nudges` | Linux |
-| 24 | Drift and snapshot failures preserve progress and recovery debt / A removed path is recreated before recovery | 4.5 | `state::sync::tests::rescan_debt_uses_current_disk_after_recreate` | Linux, Windows |
+| 23 | Drift and snapshot failures preserve progress and recovery debt / Topology marking fails | 4.5 | `state::sync::tests::durable_drift_error_advances_cursor_and_coalesces_debt` (combined end-to-end scenario) | Linux |
+| 24 | Drift and snapshot failures preserve progress and recovery debt / A removed path is recreated before recovery | 4.5 | `state::sync::tests::durable_drift_error_advances_cursor_and_coalesces_debt` (combined end-to-end scenario) | Linux, Windows |
 | 25 | Drift and snapshot failures preserve progress and recovery debt / Background snapshot preparation has a classified outcome | 4.4 | `graph::snapshot::tests::background_snapshot_preserves_all_typed_outcomes` | Linux, Windows |
 | 26 | Local contention does not repeat paid embedding work / Ownership is refused before network work | 4.6 | `state::embed::tests::failed_typed_preflight_makes_zero_network_calls` | Linux |
 | 27 | Local contention does not repeat paid embedding work / Publication is refused after vectors are returned | 4.6 | `state::embed::tests::prepared_vectors_survive_transient_publish_without_second_call` | Linux |
 | 28 | Local contention does not repeat paid embedding work / Embedding deadline is exhausted | 4.6 | `state::embed::tests::publication_deadline_moves_runtime_to_failed` | Linux |
 | 29 | Graph build retry follows the original failure / Ownership returns after transient refusal | 4.7 | `graph::build::tests::original_transient_arms_withheld_build_until_trigger` | Linux |
-| 30 | Graph build retry follows the original failure / Build operation fails while ownership probe is negative | 4.7 | `graph::build::tests::operation_error_is_not_reclassified_by_later_probe` | Linux |
+| 30 | Graph build retry follows the original failure / Build operation fails while ownership probe is negative | 4.7 | `graph::build::tests::operation_error_waits_for_fresh_work_without_losing_its_origin` | Linux |
 | 31 | The complete caller set is regression-protected / Removed generic API remains referenced | 1.6 | `inventory::no_generic_or_unclassified_production_lease_callers` | Linux |
-| 32 | The complete caller set is regression-protected / Portable exact filters run in CI | 5.3 | `workspace_lease::tests::contention_unclaimed_and_missing_are_transient`; `workspace_lease::tests::release_signal_precedes_lifecycle_wait`; `graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement`; `tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease`; `tools::search::tests::all_search_modes_are_resident_only_under_held_lease`; `tests::all_status_requests_are_cached_under_held_lease` | Linux `Check`, Windows `MCP transports + secure broker` |
+| 32 | The complete caller set is regression-protected / Portable exact filters run in CI | 5.3 | `workspace_lease::tests::contention_unclaimed_and_missing_are_transient`; `workspace_lease::tests::a_throttled_checkpoint_still_reports_a_release`; `graph::snapshot::tests::path_identity_detects_equal_size_and_time_replacement`; `tools::graph::tests::graph_data_requests_are_pool_only_under_held_lease`; `tools::search::tests::all_search_modes_are_resident_only_under_held_lease`; `tests::all_status_requests_are_cached_under_held_lease` | Linux `Check`, Windows `MCP transports + secure broker` |
 
 ## Supplemental Inventory Gates
 
 | Gate | Task | Exact planned evidence |
 |---|---:|---|
-| Heavy work remains outside lease fences | 2.11 | `inventory::prepared_work_stays_outside_lease_fences` |
+| Fence callers remain exact and request paths remain lease-free | 2.11 | `inventory::fence_callers_are_exactly_classified`; `inventory::request_paths_do_not_call_lease_or_mutation_helpers` |
 | Runtime and compatibility surface is unchanged | 5.4 | `inventory::no_new_runtime_or_compatibility_surface` |
 
 ## Required Commands
@@ -63,8 +63,8 @@ After a later explicit publication request, match the PR head SHA to the locally
 
 ## Current Status
 
-Implementation, v0.2.77 rebase integration, local verification, and both independent reviews are
-complete. Republishing the rebased PR branch remains pending.
+Implementation, v0.2.77 cancellation integration, maintainer-review repairs, and local verification
+are complete. Republishing the PR branch and live CI remain pending.
 
 ## Evidence Collected
 
@@ -73,11 +73,11 @@ complete. Republishing the rebased PR branch remains pending.
 - Traceability: an exact requirement/scenario-to-matrix comparison passed with 32 scenarios, 32 unique rows, no duplicate scenario, and every row linked to an existing task.
 - Pre-implementation strict validation: `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive` passed.
 - Pre-implementation code baseline: `workspace_lease` 24 tests, graph snapshot 19, graph build 85, bootstrap 35, sync 52, embed 25, and overlay retry 16 all passed; `cargo fmt --all -- --check` and strict Clippy for `bsl-search` plus `mcp-server` passed with no pre-existing failure.
-- Lease core: the final `workspace_lease` suite passed 39/39, including exact five-way classification, callback/lease error provenance, pre-commit restamp with zero commit calls on failure, checkpoint rollback, first-terminal precedence, same-token liveness, real foreign-token takeover, and release latency filters. The existing cross-fence restamp throttle regression also passed after separating forced short restamp from checkpointed throttling.
+- Lease core: the final `workspace_lease` suite passed, including exact five-way classification, callback/lease error provenance, pre-commit restamp with zero commit calls on failure, checkpoint rollback, first-terminal precedence, same-token liveness, real foreign-token takeover, and release latency filters. The existing cross-fence restamp throttle regression also passed after separating forced short restamp from checkpointed throttling.
 - Post-review lease correction: checkpointed work now yields and reacquires the OS lock at every
   cooperative boundary, revalidates the real lease record, and retains the reacquired guard through
   the next batch/commit. The deterministic real-record takeover test passed and the final lease
-  module suite passed 39/39.
+  module suite passed.
 - Outcome adapters: `bsl-search` has no `FenceOutcome::Terminal`; its full suite passed with 403 tests and 29 ignored. `mcp-server --all-features` compiled both production and all test targets after exhaustive host migration to distinct `Superseded` and `Released` variants.
 - Legacy surface and heartbeat: the exact `inventory::no_generic_or_unclassified_production_lease_callers` filter executed one passing test and `rg` found no legacy ownership API or `LeaseOutcome` reference under `mcp-server/src`; the exact heartbeat refusal filter passed and proves one transient miss is retried only by the next explicit tick.
 - Graph profiles: snapshot, build, and state module suites passed (19, 85, and 28 tests). Exact typed snapshot/path identity and original transient/operation provenance filters each executed one passing test; temporary graph work is off-fence, prepared installs use short publication, and fused ingest uses checkpointed 64-row boundaries.
@@ -103,8 +103,8 @@ complete. Republishing the rebased PR branch remains pending.
   preflight, one paid call across transient publication refusal, and `Failed` on deadline.
 - Exact matrix: every listed scenario, handler, and supplemental-inventory identifier executed at
   least one test and passed after the final integration changes.
-- Full gates: `bsl-search` passed 405 tests with 29 ignored; `mcp-server` passed 994 library tests
-  with 1 ignored plus 155 integration tests. Strict Clippy, rustfmt check, `git diff --check`,
+- Full gates: `bsl-search` passed 405 tests with 29 ignored; the final `mcp-server` rerun passed
+  992 library tests with 1 ignored plus every integration target. Strict Clippy, rustfmt check, `git diff --check`,
   `actionlint`, all three inventory gates, and strict non-interactive OpenSpec validation passed.
 - Full local CI follow-up: workspace-wide `RUSTFLAGS='-D warnings' cargo clippy
   --all-targets --all-features` and `RUSTFLAGS='-D warnings' cargo test --all --no-fail-fast`
@@ -120,3 +120,7 @@ complete. Republishing the rebased PR branch remains pending.
   reacquisition, record validation, and rollback; its degraded-state observation and real-handler
   evidence gaps were closed with the existing polling status, rescan debt, and four exact busy-pool
   handler tests.
+- Maintainer review: all five blocking findings were closed. Broker accept reads only the cached
+  terminal bit; CI exact filters reject zero executed tests; startup retries rerun the transaction;
+  graph operation/changed failures wait for genuinely fresh work; alias tests were deleted. The
+  held-lock status/graph tests and exact fence/request-path inventories close MID-1, MID-2, and MID-4.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
@@ -47,7 +47,7 @@ Every spec scenario has exactly one row. Identifiers are planned until implement
 ## Required Commands
 
 - Run each Rust identifier above with an exact or fully qualified filter and confirm a non-zero test count.
-- Run all `inventory::*` identifiers above and fail on any match outside the documented allow-list. The compatibility inventory executes `git diff --exit-code f8bf4da5831840070aa19477be68e74d78014fa6 -- Cargo.lock` and audits the exact added diff for thread/spawn APIs, schema/version DDL, lease-record fields, environment/config reads, and MCP serialization types.
+- Run all `inventory::*` identifiers above and fail on any match outside the documented allow-list. The compatibility inventory executes `git diff --exit-code edc78e22f3efbfe51ffd8e6dfd05b457976195ca -- Cargo.lock` and audits the exact added diff for thread/spawn APIs, schema/version DDL, lease-record fields, environment/config reads, and MCP serialization types.
 - In Linux `Check` and Windows `MCP transports + secure broker`, run each of the six portable identifiers in row 32 as `cargo test -p mcp-server <identifier> -- --exact` and require a non-zero test count.
 - `cargo fmt --all -- --check`
 - `cargo clippy -p bsl-search -p mcp-server --all-targets --all-features -- -D warnings`
@@ -63,12 +63,12 @@ After a later explicit publication request, match the PR head SHA to the locally
 
 ## Current Status
 
-Implementation, local verification, and both independent reviews are complete. Publication
-remains out of scope.
+Implementation, v0.2.77 rebase integration, local verification, and both independent reviews are
+complete. Republishing the rebased PR branch remains pending.
 
 ## Evidence Collected
 
-- Baseline: `git fetch upstream develop`; both `HEAD` and `upstream/develop` are `f8bf4da5831840070aa19477be68e74d78014fa6`; `git merge-base --is-ancestor 75b8a978 HEAD` passed; initial dirty state contained only this untracked `openspec/` tree.
+- Baseline: initial implementation started from `f8bf4da5831840070aa19477be68e74d78014fa6`; on 2026-09-04 the branch was rebased onto v0.2.77 integration base `edc78e22f3efbfe51ffd8e6dfd05b457976195ca`; `git merge-base --is-ancestor 75b8a978 HEAD` passed.
 - Caller inventory: seven production files referenced the legacy ownership APIs and ten files referenced `LeaseOutcome` or `FenceOutcome` before implementation.
 - Traceability: an exact requirement/scenario-to-matrix comparison passed with 32 scenarios, 32 unique rows, no duplicate scenario, and every row linked to an existing task.
 - Pre-implementation strict validation: `openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive` passed.
@@ -93,12 +93,17 @@ remains out of scope.
   batch creates the next enable budget.
 - Request paths: the exact graph pool-only, all-search resident-only, and all-status cached-only
   tests each executed once and passed. The four busy descriptor-pool tests also passed; status
-  uses cached lease/standalone-extension state and search only coalesces a background refresh.
+  uses cached lease/standalone extension/external-object state and search only coalesces a
+  background refresh.
+- v0.2.77 cancellation integration: six search cancellation gates and both workspace/reference
+  handler-matrix tests passed. `search_call` and `CancellationToken` remain on the request path,
+  while source inventory and the held-lease regression confirm that cancellation adds no lease
+  access, synchronous resident prefetch, or refresh wait.
 - Embedding: all three paid-work exact tests passed, proving zero network calls after failed
   preflight, one paid call across transient publication refusal, and `Failed` on deadline.
 - Exact matrix: every listed scenario, handler, and supplemental-inventory identifier executed at
   least one test and passed after the final integration changes.
-- Full gates: `bsl-search` passed 405 tests with 29 ignored; `mcp-server` passed 974 library tests
+- Full gates: `bsl-search` passed 405 tests with 29 ignored; `mcp-server` passed 994 library tests
   with 1 ignored plus 155 integration tests. Strict Clippy, rustfmt check, `git diff --check`,
   `actionlint`, all three inventory gates, and strict non-interactive OpenSpec validation passed.
 - Full local CI follow-up: workspace-wide `RUSTFLAGS='-D warnings' cargo clippy

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
@@ -42,12 +42,14 @@ Every spec scenario has exactly one row. Identifiers are planned until implement
 | Gate | Task | Exact planned evidence |
 |---|---:|---|
 | Fence callers remain exact and request paths remain lease-free | 2.11 | `inventory::fence_callers_are_exactly_classified`; `inventory::request_paths_do_not_call_lease_or_mutation_helpers` |
-| Runtime and compatibility surface is unchanged | 5.4 | `inventory::no_new_runtime_or_compatibility_surface` |
+| Source inventory works with platform checkout conventions | 7.1 | `inventory::production_prefix_handles_checkout_line_endings`; all inventory filters in Linux and Windows CI |
+| Prepared index survives swap contention and retains fresh work | 7.3 | `state::embed::tests::prepared_index_survives_transient_swap_without_rebuild` |
+| Runtime and compatibility surface is unchanged in this PR | 5.4 | One-time review of the PR diff against its merge base; not a permanent unit test |
 
 ## Required Commands
 
 - Run each Rust identifier above with an exact or fully qualified filter and confirm a non-zero test count.
-- Run all `inventory::*` identifiers above and fail on any match outside the documented allow-list. The compatibility inventory executes `git diff --exit-code edc78e22f3efbfe51ffd8e6dfd05b457976195ca -- Cargo.lock` and audits the exact added diff for thread/spawn APIs, schema/version DDL, lease-record fields, environment/config reads, and MCP serialization types.
+- Run all `inventory::*` identifiers above and fail on any match outside the documented allow-list. These tests only read checked-out Rust sources: Git history, Git executables, and a fixed `Cargo.lock` are not prerequisites. Review this PR's dependency/runtime/schema/configuration/wire diff separately against its merge base; future intentional changes are not forbidden by this PR's historical scope.
 - In Linux `Check` and Windows `MCP transports + secure broker`, run each of the six portable identifiers in row 32 as `cargo test -p mcp-server <identifier> -- --exact` and require a non-zero test count.
 - `cargo fmt --all -- --check`
 - `cargo clippy -p bsl-search -p mcp-server --all-targets --all-features -- -D warnings`
@@ -63,8 +65,11 @@ After a later explicit publication request, match the PR head SHA to the locally
 
 ## Current Status
 
-Implementation, v0.2.77 cancellation integration, maintainer-review repairs, and local verification
-are complete. Republishing the PR branch and live CI remain pending.
+PR head `949e30bb` was published and passed Linux and Windows CI on 2026-09-04.
+The 2026-09-08 follow-up for inventory portability and prepared-index retention is implemented
+locally; nine focused regressions pass on Rust 1.98. Full MCP verification is not green because
+of inotify exhaustion and a failing forced-retry references test. Publication and native Windows
+CI for this follow-up remain pending.
 
 ## Evidence Collected
 
@@ -124,3 +129,52 @@ are complete. Republishing the PR branch and live CI remain pending.
   terminal bit; CI exact filters reject zero executed tests; startup retries rerun the transaction;
   graph operation/changed failures wait for genuinely fresh work; alias tests were deleted. The
   held-lock status/graph tests and exact fence/request-path inventories close MID-1, MID-2, and MID-4.
+
+## 2026-09-08 Scoped Follow-up Evidence
+
+- Inventory no longer invokes Git or compares a lockfile to a historical SHA. All four tests
+  also passed in a source-only fixture with no `.git`, CRLF Rust files, and a deliberately changed
+  `Cargo.lock`. Native `Path` comparison replaces platform-dependent string comparison.
+- The prepared-index regression failed on the original loop: an apply event appeared between
+  two swap attempts. It passes after the fix, with and without a pending rerun; the real lease
+  lock causes refusal, only the swap is retried, and the paid embedding endpoint is called once.
+- Nine non-zero exact filters passed on Rust 1.98: all four inventory tests, prepared-index
+  retention, paid-vector retention, publication deadline, supersession, and the mid-flight rerun.
+  Linux and Windows CI now include the inventory and prepared-index filters.
+- `bsl-search` passed 405 tests with 29 ignored. The full MCP run was not accepted: its library
+  had 822 passed / 171 failed / 1 ignored, and integration targets had 154 passed / 1 failed.
+  A library-only rerun with four test threads still had 145 failures; reducing concurrency did
+  not remove the environment problem.
+- Temporary diagnostic output identified notify `MaxFilesWatch`. The host had 1,048,405 visible
+  watch references against a per-user limit of 1,048,576. The diagnostic changes were removed;
+  system limits and other processes were not changed. The poisoned-lock failures in the broad
+  run do not replace the separate, passing focused regression results.
+- The `references` integration target's `a_name_declared_after_the_last_scan_is_found_on_a_forced_retry`
+  test also failed in isolation: a newly added method returned `not_found` with graph `not_ready`. Its cause has not
+  been established by this follow-up; no references or watcher production code was changed.
+- Rust 1.98 is selected for both Cargo and its child tools by explicit toolchain paths; selecting
+  Cargo alone picked up a different `rustc` from this host's PATH. Clean workspace
+  `RUSTFLAGS='-D warnings' cargo clippy --all-targets --all-features` passed with Clippy 0.1.98,
+  using separate target and temporary directories on the workspace disk. Rustfmt 1.98,
+  workflow actionlint, strict OpenSpec validation, and `git diff --check` passed.
+
+## 2026-09-09 Final Follow-up Verification
+
+- The host inotify shortage was corrected in the active VS Code profile outside this repository.
+  The forced-retry references test passed unchanged both alone and in the complete suite.
+- The first post-inotify suite exposed a separate, reproducible graph build collision: overlapping
+  backend generations within one process used the same PID-only temporary SQLite path. Tracing
+  captured `disk I/O error` and `attempt to write a readonly database` during their concurrent
+  reloads. Temporary tracing instrumentation was removed after diagnosis.
+- Full and incremental graph builds now share a PID-plus-build-counter path allocator. The
+  superseded-build regression failed deterministically with the old PID-only path, then passed
+  with the fix; it also proves refusal and fused failure leave another build's file untouched.
+  No dependency, worker, persistent cache schema, lease record, configuration, or wire change
+  was introduced.
+- The final Rust 1.98 `cargo test -p bsl-search -p mcp-server --all-features --no-fail-fast`
+  passed: `bsl-search` 405 passed / 29 ignored, MCP library 993 passed / 1 ignored, and all
+  integration targets passed, including `superseded_daemon_lifecycle` and the references retry.
+- Strict workspace Clippy (`RUSTFLAGS='-D warnings' cargo clippy --all-targets --all-features`)
+  passed after the graph fix. Formatting, workflow lint, strict OpenSpec validation, and diff
+  checks passed. The earlier non-zero exact-filter and source-only/CRLF inventory evidence
+  remains applicable; the final library suite includes the inventory and prepared-index tests.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
@@ -190,3 +190,19 @@ CI for this follow-up remain pending.
   withheld; the two positive controls release the lock and still require `answered` afterward.
   All six `name_dictionary` transport tests passed with the deterministic fixture. Production
   behavior is unchanged. Windows CI explicitly runs this suite to verify its lock behavior too.
+
+## 2026-09-11 Maintainer Rebase
+
+The user approved rebasing and updating PR #119 onto current `upstream/develop`.
+The original head `03fcb358f591ffdc8b791550de245f5966b508de` is retained at
+`backup/pr119-before-rebase-20260911`; the new base is
+`7133432d276d7fb1f5e21168e0cc59ff7f8b861e` (v0.2.79).
+Work takes place in a separate worktree, preserving PR #142 and unrelated local changes.
+
+The name-dictionary conflict keeps upstream provider-identity assertions and the
+held-lease fixture, including both publication-after-release controls. Four embedding
+tests use upstream's existing `env_lock()` helper. Three diagnostics helpers have the
+same Unix gate as their only caller. The selective baseline LSP fixture publishes
+complete snapshots atomically, avoiding the intermediate empty-file error epoch already
+reproduced and fixed during PR #142 verification. Production scope is unchanged.
+Validation of this rebased tree follows; previous dated results are historical evidence.

--- a/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
+++ b/openspec/changes/enforce-workspace-lease-operation-profiles/verification.md
@@ -178,3 +178,15 @@ CI for this follow-up remain pending.
   passed after the graph fix. Formatting, workflow lint, strict OpenSpec validation, and diff
   checks passed. The earlier non-zero exact-filter and source-only/CRLF inventory evidence
   remains applicable; the final library suite includes the inventory and prepared-index tests.
+
+## 2026-09-09 CI Fixture Follow-up
+
+- CI on `c123df62` passed Windows and the Linux formatting, Clippy, and exact-filter gates.
+  The full Linux suite exposed `names_resolve_before_the_graph_exists`: its fixture assumed
+  the background graph would still be unavailable after the independent resident became ready,
+  but the graph provider had already reached `answered`.
+- The four cold-graph name-dictionary scenarios now hold the real cache lease lock before
+  backend construction. Dictionary answers remain available while graph publication is
+  withheld; the two positive controls release the lock and still require `answered` afterward.
+  All six `name_dictionary` transport tests passed with the deterministic fixture. Production
+  behavior is unchanged. Windows CI explicitly runs this suite to verify its lock behavior too.


### PR DESCRIPTION
## Summary

- replace generic workspace lease fencing with explicit short-publication and checkpointed-transaction profiles
- preserve exhaustive Applied, OperationError, TransientRefusal, Superseded, and Released outcomes with original error provenance
- keep request-time graph, search, diagnostics, metadata, and status paths on resident or cached state
- bound retry obligations while retaining prepared graph, drift, overlay, and paid embedding work, including an already-built vector index across transient swap refusal
- isolate temporary graph databases for backend generations that overlap within one process
- enforce source-only caller inventories without Git history or a frozen lockfile; cover Windows paths and CRLF checkouts with non-zero Linux/Windows regression filters
- include the complete OpenSpec change and requirement-level verification evidence

## Verification

Rebased onto `upstream/develop` at `7133432d276d7fb1f5e21168e0cc59ff7f8b861e` (v0.2.79).
The name-dictionary integration retains upstream provider assertions and explicit lease control.
Embedding tests use upstream's environment-lock helper; Unix-only diagnostics helpers are gated;
the baseline LSP fixture publishes complete snapshots atomically.

- cargo fmt --all -- --check: passed
- actionlint .github/workflows/ci.yml: passed
- git diff --check: passed
- openspec validate enforce-workspace-lease-operation-profiles --strict --no-interactive: passed
- `RUSTFLAGS='-D warnings' cargo clippy --all-targets --all-features`: passed
- `RUSTFLAGS='-D warnings' cargo test --all --no-fail-fast`: passed, 9882 tests passed / 0 failed / 66 ignored across 276 targets
- all six `name_dictionary` transport tests passed, including both held-lease/release controls
- [CI run 34582266345](https://github.com/itrous/bsl-analyzer/actions/runs/34582266345) on `1f61fb05bc75b32ca502a5f3ba7b682a6e3a1bd7`: Linux `Check` and `Windows MCP transports + secure broker` both completed successfully
- the 1.6M release scale job is intentionally skipped for pull requests by the upstream workflow

The results above apply to this rebased head. Previous dated verification remains in the OpenSpec evidence as historical context.

Closes #71
